### PR TITLE
Allow listObjects to work without filter parameters

### DIFF
--- a/src/__tests__/e2e/crud/listObjects.e2e.test.ts
+++ b/src/__tests__/e2e/crud/listObjects.e2e.test.ts
@@ -1804,26 +1804,68 @@ describe("E2E CRUD - listObjects", () => {
       expect(Array.isArray(objects)).toBe(true);
     });
 
-    it("should require at least one filter when type is omitted", async () => {
+    it("should return all objects when no filters are provided", async () => {
+      // Create some test objects first
+      await createObjectFile(
+        testEnv.projectRoot,
+        "task",
+        "T-no-filter-test",
+        createObjectContent({
+          id: "T-no-filter-test",
+          title: "No Filter Test Task",
+          status: "open",
+          priority: "high",
+        }),
+        { status: "open" },
+      );
+
+      await createObjectFile(
+        testEnv.projectRoot,
+        "project",
+        "P-no-filter-test",
+        createObjectContent({
+          id: "P-no-filter-test",
+          title: "No Filter Test Project",
+          status: "open",
+          priority: "medium",
+        }),
+      );
+
       const result = await client.callTool("list_issues", {});
 
-      expect(result.content[0].text).toContain("Error listing objects");
-      expect(result.content[0].text).toContain(
-        "At least one filter parameter (type, status, priority, or scope) must be provided",
-      );
+      const objects = extractObjectIds(result.content[0].text as string);
+      // Should return all objects without error
+      expect(Array.isArray(objects)).toBe(true);
+      expect(objects.length).toBeGreaterThan(0);
+      expect(objects).toContain("T-no-filter-test");
+      expect(objects).toContain("P-no-filter-test");
     });
 
-    it("should handle empty arrays in all parameters", async () => {
+    it("should handle empty arrays in all parameters as no filter", async () => {
+      // Create some test objects first
+      await createObjectFile(
+        testEnv.projectRoot,
+        "feature",
+        "F-empty-array-test",
+        createObjectContent({
+          id: "F-empty-array-test",
+          title: "Empty Array Test Feature",
+          status: "open",
+          priority: "low",
+        }),
+      );
+
       const result = await client.callTool("list_issues", {
         type: [],
         status: [],
         priority: [],
       });
 
-      expect(result.content[0].text).toContain("Error listing objects");
-      expect(result.content[0].text).toContain(
-        "At least one filter parameter (type, status, priority, or scope) must be provided",
-      );
+      const objects = extractObjectIds(result.content[0].text as string);
+      // Should return all objects without error
+      expect(Array.isArray(objects)).toBe(true);
+      expect(objects.length).toBeGreaterThan(0);
+      expect(objects).toContain("F-empty-array-test");
     });
   });
 });

--- a/src/tools/__tests__/listObjectsTool.test.ts
+++ b/src/tools/__tests__/listObjectsTool.test.ts
@@ -551,22 +551,24 @@ describe("listObjectsTool", () => {
         );
       });
 
-      it("should return error when all arrays are empty and no other filters", async () => {
+      it("should handle empty arrays as no filter provided", async () => {
+        mockService.listObjects.mockResolvedValue(mockResponse);
+
         const result = await handleListObjects(mockService, mockRepository, {
           type: [],
           status: [],
           priority: [],
         });
 
-        expect(result).toEqual({
-          content: [
-            {
-              type: "text",
-              text: "Error listing objects: At least one filter parameter (type, status, priority, or scope) must be provided",
-            },
-          ],
-        });
-        expect(mockService.listObjects).not.toHaveBeenCalled();
+        expect(mockService.listObjects).toHaveBeenCalledWith(
+          mockRepository,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+        );
+        expect(result).toEqual(mockResponse);
       });
 
       it("should handle empty parameter object with scope filter", async () => {
@@ -584,6 +586,22 @@ describe("listObjectsTool", () => {
           undefined,
           false,
         );
+      });
+
+      it("should handle no filter parameters and return all objects", async () => {
+        mockService.listObjects.mockResolvedValue(mockResponse);
+
+        const result = await handleListObjects(mockService, mockRepository, {});
+
+        expect(mockService.listObjects).toHaveBeenCalledWith(
+          mockRepository,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          false,
+        );
+        expect(result).toEqual(mockResponse);
       });
 
       // Backward compatibility tests

--- a/src/tools/listObjectsTool.ts
+++ b/src/tools/listObjectsTool.ts
@@ -200,13 +200,6 @@ export async function handleListObjects(
     const statusEnums = toStatusArray(status);
     const priorityEnums = toPriorityArray(priority);
 
-    // Validate that at least one filter is provided when type is optional
-    if (!typeEnums && !statusEnums && !priorityEnums && !scope) {
-      throw new Error(
-        "At least one filter parameter (type, status, priority, or scope) must be provided",
-      );
-    }
-
     // Convert arrays back to single values or keep as arrays based on service signature
     const typeParam = typeEnums
       ? typeEnums.length === 1


### PR DESCRIPTION
Changes enable the `listObjects` function to return all objects when no filter parameters are provided, improving usability and flexibility. Adjustments in tests ensure proper handling of scenarios with no filters.