### PR TITLE
Add attachments on Trellis issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,13 @@ Task Trellis UI: http://127.0.0.1:3717
 - **append_issue_log** - Add progress notes and status updates to task history (occurs automatically on task completion)
 - **append_modified_files** - Record files modified during task execution with change descriptions (occurs automatically on task completion)
 
+### Attachment Management
+
+- **add_attachment** - Copy a file into the managed attachments folder for an issue (errors if the issue or source file does not exist, or a file with the same name already exists)
+- **remove_attachment** - Delete a named file from an issue's attachments folder (errors if the issue or file does not exist)
+
+Attachments are returned as a list of filenames when calling **get_issue** and are linked in the browser UI detail view.
+
 ### Browser UI
 
 - **get_ui_info** - Returns the URL and port of the Task Trellis browser UI; use when the user asks about the UI or wants to view issues in a browser

--- a/src/__tests__/serverStartup.test.ts
+++ b/src/__tests__/serverStartup.test.ts
@@ -33,6 +33,10 @@ const mockRepository: jest.Mocked<Repository> = {
   saveObject: jest.fn(),
   deleteObject: jest.fn(),
   getChildrenOf: jest.fn(),
+  getAttachmentsFolder: jest.fn(),
+  listAttachments: jest.fn(),
+  copyAttachment: jest.fn(),
+  deleteAttachment: jest.fn(),
 };
 
 const mockService: jest.Mocked<TaskTrellisService> = {
@@ -45,6 +49,8 @@ const mockService: jest.Mocked<TaskTrellisService> = {
   getNextAvailableIssue: jest.fn(),
   completeTask: jest.fn(),
   pruneClosed: jest.fn(),
+  addAttachment: jest.fn(),
+  removeAttachment: jest.fn(),
 };
 
 // Mock the repository and service getter functions

--- a/src/http/__tests__/attachmentHandler.test.ts
+++ b/src/http/__tests__/attachmentHandler.test.ts
@@ -1,0 +1,163 @@
+jest.mock("node:fs");
+jest.mock("node:fs/promises");
+jest.mock("../../configuration/resolveDataDir");
+jest.mock("../../repositories/local/LocalRepository");
+
+import fs from "node:fs";
+import { stat } from "node:fs/promises";
+import { EventEmitter } from "node:events";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { resolveDataDir } from "../../configuration/resolveDataDir";
+import { LocalRepository } from "../../repositories/local/LocalRepository";
+import { attachmentHandler } from "../projectTreePage/attachmentHandler";
+
+const mockResolveDataDir = resolveDataDir as jest.MockedFunction<
+  typeof resolveDataDir
+>;
+const MockedLocalRepository = LocalRepository as jest.MockedClass<
+  typeof LocalRepository
+>;
+const mockExistsSync = fs.existsSync as jest.Mock;
+const mockCreateReadStream = fs.createReadStream as jest.Mock;
+const mockStat = stat as jest.Mock;
+
+const makeRes = () =>
+  ({
+    writeHead: jest.fn(),
+    end: jest.fn(),
+    headersSent: false,
+  }) as unknown as ServerResponse;
+
+const makeReq = () => ({ url: "/" }) as IncomingMessage;
+
+function makeStream() {
+  const emitter = new EventEmitter() as NodeJS.ReadableStream & {
+    pipe: jest.Mock;
+  };
+  (emitter as { pipe: jest.Mock }).pipe = jest.fn();
+  return emitter;
+}
+
+describe("attachmentHandler", () => {
+  let mockGetObjectById: jest.Mock;
+  let mockGetAttachmentsFolder: jest.Mock;
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockGetObjectById = jest.fn().mockResolvedValue({
+      id: "T-test",
+      type: "task",
+    });
+    mockGetAttachmentsFolder = jest
+      .fn()
+      .mockResolvedValue("/data/projects/my-proj/t/attachments/T-test");
+    MockedLocalRepository.mockImplementation(
+      () =>
+        ({
+          getObjectById: mockGetObjectById,
+          getAttachmentsFolder: mockGetAttachmentsFolder,
+        }) as unknown as LocalRepository,
+    );
+    mockResolveDataDir.mockReturnValue("/data");
+    mockExistsSync.mockReturnValue(true);
+    mockStat.mockResolvedValue({});
+    mockCreateReadStream.mockReturnValue(makeStream());
+  });
+
+  it("returns 200 with correct content-type for a known attachment", async () => {
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-test",
+      filename: "diagram.png",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(200);
+    expect((res.writeHead as jest.Mock).mock.calls[0][1]).toMatchObject({
+      "Content-Type": "image/png",
+    });
+    expect(mockCreateReadStream).toHaveBeenCalledWith(
+      expect.stringContaining("diagram.png"),
+    );
+  });
+
+  it("returns 200 with octet-stream for unknown extension", async () => {
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-test",
+      filename: "data.bin",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(200);
+    expect((res.writeHead as jest.Mock).mock.calls[0][1]).toMatchObject({
+      "Content-Type": "application/octet-stream",
+    });
+  });
+
+  it("returns 404 when file is not found in attachments folder", async () => {
+    mockStat.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-test",
+      filename: "missing.txt",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(404);
+  });
+
+  it("returns 404 when issue does not exist", async () => {
+    mockGetObjectById.mockResolvedValue(null);
+
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-missing",
+      filename: "file.txt",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(404);
+    expect(mockGetAttachmentsFolder).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when project key does not match an existing project", async () => {
+    mockExistsSync.mockReturnValue(false);
+
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "no-such-proj",
+      id: "T-test",
+      filename: "file.txt",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(404);
+    expect(mockGetObjectById).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for filenames containing path traversal sequences", async () => {
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-test",
+      filename: "../secret.txt",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(400);
+    expect(mockGetObjectById).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 for filenames containing forward slash", async () => {
+    const res = makeRes();
+    await attachmentHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-test",
+      filename: "sub/evil.txt",
+    });
+
+    expect((res.writeHead as jest.Mock).mock.calls[0][0]).toBe(400);
+  });
+});

--- a/src/http/__tests__/projectTreePage.test.ts
+++ b/src/http/__tests__/projectTreePage.test.ts
@@ -240,13 +240,18 @@ describe("searchHandler", () => {
 
 describe("detailViewHandler", () => {
   let mockGetObjectById: jest.Mock;
+  let mockListAttachments: jest.Mock;
 
   beforeEach(() => {
     jest.resetAllMocks();
     mockGetObjectById = jest.fn().mockResolvedValue(null);
+    mockListAttachments = jest.fn().mockResolvedValue([]);
     MockedLocalRepository.mockImplementation(
       () =>
-        ({ getObjectById: mockGetObjectById }) as unknown as LocalRepository,
+        ({
+          getObjectById: mockGetObjectById,
+          listAttachments: mockListAttachments,
+        }) as unknown as LocalRepository,
     );
     mockResolveDataDir.mockReturnValue("/test/data");
   });
@@ -456,5 +461,45 @@ describe("detailViewHandler", () => {
     expect(html).toContain("No prerequisites.");
     expect(html).toContain("No log entries.");
     expect(html).toContain("No modified files.");
+  });
+
+  it("renders attachment links when attachments are present", async () => {
+    mockGetObjectById.mockResolvedValue(
+      makeObj({ id: "T-attach", title: "Attach Task", parent: null }),
+    );
+    mockListAttachments.mockResolvedValue(["diagram.png", "notes.txt"]);
+
+    const res = makeRes();
+    await detailViewHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-attach",
+    });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain("Attachments");
+    expect(html).toContain(
+      'href="/projects/my-proj/issues/T-attach/attachments/diagram.png"',
+    );
+    expect(html).toContain(
+      'href="/projects/my-proj/issues/T-attach/attachments/notes.txt"',
+    );
+    expect(html).toContain("diagram.png");
+    expect(html).toContain("notes.txt");
+  });
+
+  it("renders no attachments section when list is empty", async () => {
+    mockGetObjectById.mockResolvedValue(
+      makeObj({ id: "T-noattach", parent: null }),
+    );
+    mockListAttachments.mockResolvedValue([]);
+
+    const res = makeRes();
+    await detailViewHandler(makeReq(), res, {
+      key: "my-proj",
+      id: "T-noattach",
+    });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).not.toContain("Attachments");
   });
 });

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { landingPageHandler } from "./landingPage";
 import {
+  attachmentHandler,
   createChildFormHandler,
   createChildSubmitHandler,
   createTopFormHandler,
@@ -46,6 +47,10 @@ function buildRouter() {
   );
   router.get("/projects/:key/issues/:id/detail", (req, res, params) =>
     detailViewHandler(req, res, params),
+  );
+  router.get(
+    "/projects/:key/issues/:id/attachments/:filename",
+    (req, res, params) => attachmentHandler(req, res, params),
   );
   router.get("/projects/:key/issues/:id/edit", (req, res, params) =>
     editFormHandler(req, res, params),

--- a/src/http/projectTreePage/attachmentHandler.ts
+++ b/src/http/projectTreePage/attachmentHandler.ts
@@ -1,0 +1,91 @@
+import { createReadStream, existsSync } from "node:fs";
+import { stat } from "node:fs/promises";
+import type { IncomingMessage, ServerResponse } from "node:http";
+import { extname, join } from "node:path";
+import { resolveDataDir } from "../../configuration/resolveDataDir";
+import { makeRepo } from "./makeRepo";
+
+const MIME_TYPES: Record<string, string> = {
+  ".css": "text/css",
+  ".csv": "text/csv",
+  ".gif": "image/gif",
+  ".html": "text/html",
+  ".jpeg": "image/jpeg",
+  ".jpg": "image/jpeg",
+  ".js": "application/javascript",
+  ".json": "application/json",
+  ".md": "text/plain",
+  ".pdf": "application/pdf",
+  ".png": "image/png",
+  ".svg": "image/svg+xml",
+  ".txt": "text/plain",
+  ".webp": "image/webp",
+  ".zip": "application/zip",
+};
+
+function mimeType(filename: string): string {
+  return (
+    MIME_TYPES[extname(filename).toLowerCase()] ?? "application/octet-stream"
+  );
+}
+
+function send404(res: ServerResponse): void {
+  res.writeHead(404, { "Content-Type": "text/plain" });
+  res.end("404 Not Found");
+}
+
+function serveFile(
+  filePath: string,
+  filename: string,
+  res: ServerResponse,
+): void {
+  res.writeHead(200, { "Content-Type": mimeType(filename) });
+  const stream = createReadStream(filePath);
+  stream.on("error", () => {
+    if (!res.headersSent) {
+      res.writeHead(500, { "Content-Type": "text/plain" });
+      res.end("500 Internal Server Error");
+    }
+  });
+  stream.pipe(res);
+}
+
+/** Handles GET /projects/:key/issues/:id/attachments/:filename */
+export async function attachmentHandler(
+  _req: IncomingMessage,
+  res: ServerResponse,
+  params: Record<string, string>,
+): Promise<void> {
+  const { key, id, filename } = params;
+
+  if (filename.includes("/") || filename.includes("..")) {
+    res.writeHead(400, { "Content-Type": "text/plain" });
+    res.end("400 Bad Request");
+    return;
+  }
+
+  if (!existsSync(join(resolveDataDir(), "projects", key))) {
+    send404(res);
+    return;
+  }
+
+  const repo = makeRepo(key);
+  const obj = await repo.getObjectById(id);
+
+  if (!obj) {
+    send404(res);
+    return;
+  }
+
+  const folder = await repo.getAttachmentsFolder(id);
+  const filePath = join(folder, filename);
+
+  try {
+    await stat(filePath);
+  } catch {
+    send404(res);
+    return;
+  }
+
+  serveFile(filePath, filename, res);
+}

--- a/src/http/projectTreePage/detailViewHandler.ts
+++ b/src/http/projectTreePage/detailViewHandler.ts
@@ -19,6 +19,7 @@ export async function detailViewHandler(
     return;
   }
 
+  const attachments = await repo.listAttachments(id);
   res.writeHead(200, { "Content-Type": "text/html" });
-  res.end(await renderDetailView(key, obj, repo));
+  res.end(await renderDetailView(key, obj, repo, attachments));
 }

--- a/src/http/projectTreePage/index.ts
+++ b/src/http/projectTreePage/index.ts
@@ -1,3 +1,4 @@
+export { attachmentHandler } from "./attachmentHandler";
 export { createChildFormHandler } from "./createChildFormHandler";
 export { createChildSubmitHandler } from "./createChildSubmitHandler";
 export { createTopFormHandler } from "./createTopFormHandler";

--- a/src/http/projectTreePage/renderDetailView.ts
+++ b/src/http/projectTreePage/renderDetailView.ts
@@ -66,6 +66,7 @@ export async function renderDetailView(
   key: string,
   obj: TrellisObject,
   repo: Repository,
+  attachments: string[] = [],
 ): Promise<string> {
   const breadcrumbs = await buildBreadcrumbs(key, obj, repo);
   const keyEsc = escapeHtml(key);
@@ -126,6 +127,19 @@ export async function renderDetailView(
       .join("")}</ul>`;
   }
 
+  const attachmentsList =
+    attachments.length > 0
+      ? `<div class="field-group">
+    <div class="field-label">Attachments</div>
+    <ul class="prereq-list">${attachments
+      .map(
+        (name) =>
+          `<li><a href="/projects/${keyEsc}/issues/${idEsc}/attachments/${encodeURIComponent(name)}">${escapeHtml(name)}</a></li>`,
+      )
+      .join("")}</ul>
+  </div>`
+      : "";
+
   return `<div data-view="view">
   ${breadcrumbs}
   ${titleRow}
@@ -134,6 +148,7 @@ export async function renderDetailView(
     <div class="field-label">Description</div>
     ${description}
   </div>
+  ${attachmentsList}
   <div class="field-group">
     <div class="field-label">Prerequisites</div>
     ${prerequisites}

--- a/src/repositories/Repository.ts
+++ b/src/repositories/Repository.ts
@@ -20,4 +20,8 @@ export interface Repository {
   ): Promise<TrellisObject[]>;
   saveObject(trellisObject: TrellisObject): Promise<void>;
   deleteObject(id: string, force?: boolean): Promise<void>;
+  getAttachmentsFolder(id: string): Promise<string>;
+  listAttachments(id: string): Promise<string[]>;
+  copyAttachment(id: string, sourcePath: string): Promise<string>;
+  deleteAttachment(id: string, filename: string): Promise<void>;
 }

--- a/src/repositories/local/LocalRepository.ts
+++ b/src/repositories/local/LocalRepository.ts
@@ -71,4 +71,24 @@ export class LocalRepository implements Repository {
     const { deleteObjectById } = await import("./deleteObjectById");
     await deleteObjectById(id, this.config.planningRootFolder!, force);
   }
+
+  async getAttachmentsFolder(id: string): Promise<string> {
+    const { getAttachmentsFolder } = await import("./getAttachmentsFolder.js");
+    return getAttachmentsFolder(id, this.config.planningRootFolder!);
+  }
+
+  async listAttachments(id: string): Promise<string[]> {
+    const { listAttachments } = await import("./listAttachments.js");
+    return listAttachments(id, this.config.planningRootFolder!);
+  }
+
+  async copyAttachment(id: string, sourcePath: string): Promise<string> {
+    const { copyAttachment } = await import("./copyAttachment.js");
+    return copyAttachment(id, sourcePath, this.config.planningRootFolder!);
+  }
+
+  async deleteAttachment(id: string, filename: string): Promise<void> {
+    const { deleteAttachment } = await import("./deleteAttachment.js");
+    return deleteAttachment(id, filename, this.config.planningRootFolder!);
+  }
 }

--- a/src/repositories/local/__tests__/copyAttachment.test.ts
+++ b/src/repositories/local/__tests__/copyAttachment.test.ts
@@ -1,0 +1,72 @@
+import * as fsp from "fs/promises";
+import * as getAttachmentsFolderModule from "../getAttachmentsFolder";
+import { copyAttachment } from "../copyAttachment";
+
+jest.mock("fs/promises");
+jest.mock("../getAttachmentsFolder");
+
+const mockAccess = jest.mocked(fsp.access);
+const mockMkdir = jest.mocked(fsp.mkdir);
+const mockCopyFile = jest.mocked(fsp.copyFile);
+const mockGetAttachmentsFolder = jest.mocked(
+  getAttachmentsFolderModule.getAttachmentsFolder,
+);
+
+describe("copyAttachment", () => {
+  const root = "/planning";
+  const folder = "/planning/f/F-feat/attachments";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAttachmentsFolder.mockResolvedValue(folder);
+    // Default: source exists, dest does not exist
+    mockAccess.mockImplementation((p) => {
+      if (String(p).includes("attachments/report.pdf")) {
+        return Promise.reject(
+          Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+        );
+      }
+      return Promise.resolve();
+    });
+    mockMkdir.mockResolvedValue(undefined as unknown as string);
+    mockCopyFile.mockResolvedValue(undefined);
+  });
+
+  it("copies file and returns filename on success", async () => {
+    const result = await copyAttachment("F-feat", "/tmp/report.pdf", root);
+    expect(result).toBe("report.pdf");
+    expect(mockMkdir).toHaveBeenCalledWith(folder, { recursive: true });
+    expect(mockCopyFile).toHaveBeenCalledWith(
+      "/tmp/report.pdf",
+      `${folder}/report.pdf`,
+    );
+  });
+
+  it("throws when source file does not exist", async () => {
+    mockAccess.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    await expect(
+      copyAttachment("F-feat", "/tmp/missing.pdf", root),
+    ).rejects.toThrow("Source file '/tmp/missing.pdf' does not exist");
+  });
+
+  it("throws when issue does not exist", async () => {
+    mockGetAttachmentsFolder.mockRejectedValueOnce(
+      new Error("Object with ID 'F-missing' not found"),
+    );
+    await expect(
+      copyAttachment("F-missing", "/tmp/report.pdf", root),
+    ).rejects.toThrow("Object with ID 'F-missing' not found");
+  });
+
+  it("throws on filename collision", async () => {
+    // Both source and dest exist
+    mockAccess.mockResolvedValue(undefined);
+    await expect(
+      copyAttachment("F-feat", "/tmp/report.pdf", root),
+    ).rejects.toThrow(
+      "File 'report.pdf' already exists in attachments for F-feat",
+    );
+  });
+});

--- a/src/repositories/local/__tests__/deleteAttachment.test.ts
+++ b/src/repositories/local/__tests__/deleteAttachment.test.ts
@@ -1,0 +1,49 @@
+import * as fsp from "fs/promises";
+import * as getAttachmentsFolderModule from "../getAttachmentsFolder";
+import { deleteAttachment } from "../deleteAttachment";
+
+jest.mock("fs/promises");
+jest.mock("../getAttachmentsFolder");
+
+const mockAccess = jest.mocked(fsp.access);
+const mockUnlink = jest.mocked(fsp.unlink);
+const mockGetAttachmentsFolder = jest.mocked(
+  getAttachmentsFolderModule.getAttachmentsFolder,
+);
+
+describe("deleteAttachment", () => {
+  const root = "/planning";
+  const folder = "/planning/f/F-feat/attachments";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAttachmentsFolder.mockResolvedValue(folder);
+    mockAccess.mockResolvedValue(undefined);
+    mockUnlink.mockResolvedValue(undefined);
+  });
+
+  it("deletes the file on success", async () => {
+    await deleteAttachment("F-feat", "report.pdf", root);
+    expect(mockUnlink).toHaveBeenCalledWith(`${folder}/report.pdf`);
+  });
+
+  it("throws when the file does not exist", async () => {
+    mockAccess.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    await expect(
+      deleteAttachment("F-feat", "missing.pdf", root),
+    ).rejects.toThrow(
+      "File 'missing.pdf' does not exist in attachments for F-feat",
+    );
+  });
+
+  it("throws when the issue does not exist", async () => {
+    mockGetAttachmentsFolder.mockRejectedValueOnce(
+      new Error("Object with ID 'F-missing' not found"),
+    );
+    await expect(
+      deleteAttachment("F-missing", "report.pdf", root),
+    ).rejects.toThrow("Object with ID 'F-missing' not found");
+  });
+});

--- a/src/repositories/local/__tests__/deleteObjectById.test.ts
+++ b/src/repositories/local/__tests__/deleteObjectById.test.ts
@@ -1,5 +1,5 @@
 import { join } from "path";
-import { cp, rm, access, readdir, writeFile } from "fs/promises";
+import { cp, rm, access, readdir, writeFile, mkdir } from "fs/promises";
 import { constants } from "fs";
 import { TrellisObjectType } from "../../../models";
 import { deleteObjectById } from "../deleteObjectById";
@@ -331,6 +331,74 @@ This task depends on T-setup-database.
       await expect(
         deleteObjectById("T-setup-database", "/non/existent/path"),
       ).rejects.toThrow();
+    });
+  });
+
+  describe("Attachment cleanup", () => {
+    it("should remove project attachments/ subfolder as part of recursive folder delete", async () => {
+      const attachmentsPath = join(
+        testPlanningRoot,
+        "p",
+        "P-ecommerce-platform",
+        "attachments",
+      );
+      await mkdir(attachmentsPath, { recursive: true });
+      await writeFile(join(attachmentsPath, "spec.pdf"), "data");
+
+      await deleteObjectById("P-ecommerce-platform", testPlanningRoot);
+
+      await expect(access(attachmentsPath, constants.F_OK)).rejects.toThrow();
+    });
+
+    it("should remove attachments folder when deleting a parented task", async () => {
+      const attachmentsPath = join(
+        testPlanningRoot,
+        "f",
+        "F-user-authentication",
+        "t",
+        "attachments",
+        "T-implement-login",
+      );
+      await mkdir(attachmentsPath, { recursive: true });
+      await writeFile(join(attachmentsPath, "notes.txt"), "data");
+
+      await deleteObjectById("T-implement-login", testPlanningRoot);
+
+      const result = await getObjectById("T-implement-login", testPlanningRoot);
+      expect(result).toBeNull();
+      await expect(access(attachmentsPath, constants.F_OK)).rejects.toThrow();
+      // Parent feature folder still exists
+      const featureFolderPath = join(
+        testPlanningRoot,
+        "f",
+        "F-user-authentication",
+      );
+      await expect(
+        access(featureFolderPath, constants.F_OK),
+      ).resolves.not.toThrow();
+    });
+
+    it("should remove attachments folder when deleting a standalone task", async () => {
+      const attachmentsPath = join(
+        testPlanningRoot,
+        "t",
+        "attachments",
+        "T-setup-database",
+      );
+      await mkdir(attachmentsPath, { recursive: true });
+      await writeFile(join(attachmentsPath, "notes.txt"), "data");
+
+      await deleteObjectById("T-setup-database", testPlanningRoot);
+
+      const result = await getObjectById("T-setup-database", testPlanningRoot);
+      expect(result).toBeNull();
+      await expect(access(attachmentsPath, constants.F_OK)).rejects.toThrow();
+    });
+
+    it("should not throw when task attachments folder does not exist", async () => {
+      await expect(
+        deleteObjectById("T-implement-login", testPlanningRoot),
+      ).resolves.not.toThrow();
     });
   });
 

--- a/src/repositories/local/__tests__/getAttachmentsFolder.test.ts
+++ b/src/repositories/local/__tests__/getAttachmentsFolder.test.ts
@@ -1,0 +1,156 @@
+import { join } from "path";
+import {
+  TrellisObject,
+  TrellisObjectPriority,
+  TrellisObjectStatus,
+  TrellisObjectType,
+} from "../../../models";
+import * as getObjectByIdModule from "../getObjectById";
+import { getAttachmentsFolder } from "../getAttachmentsFolder";
+
+jest.mock("../getObjectById");
+const mockGetObjectById = jest.mocked(getObjectByIdModule.getObjectById);
+
+describe("getAttachmentsFolder", () => {
+  const root = "/test/planning/root";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const makeObj = (
+    id: string,
+    type: TrellisObjectType,
+    parent: string | null = null,
+  ): TrellisObject => ({
+    id,
+    type,
+    title: `Test ${id}`,
+    status: TrellisObjectStatus.OPEN,
+    priority: TrellisObjectPriority.MEDIUM,
+    parent,
+    prerequisites: [],
+    affectedFiles: new Map(),
+    log: [],
+    schema: "1.0",
+    childrenIds: [],
+    body: "",
+    created: "2025-01-15T10:00:00Z",
+    updated: "2025-01-15T10:00:00Z",
+  });
+
+  it("throws when issue not found", async () => {
+    mockGetObjectById.mockResolvedValueOnce(null);
+    await expect(getAttachmentsFolder("T-missing", root)).rejects.toThrow(
+      "Object with ID 'T-missing' not found",
+    );
+  });
+
+  it("returns correct path for a Project", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("P-proj", TrellisObjectType.PROJECT),
+    );
+    const result = await getAttachmentsFolder("P-proj", root);
+    expect(result).toBe(join(root, "p", "P-proj", "attachments"));
+  });
+
+  it("returns correct path for a standalone Epic", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("E-epic", TrellisObjectType.EPIC),
+    );
+    const result = await getAttachmentsFolder("E-epic", root);
+    expect(result).toBe(join(root, "e", "E-epic", "attachments"));
+  });
+
+  it("returns correct path for an Epic with parent project", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("E-epic", TrellisObjectType.EPIC, "P-proj"),
+    );
+    const result = await getAttachmentsFolder("E-epic", root);
+    expect(result).toBe(
+      join(root, "p", "P-proj", "e", "E-epic", "attachments"),
+    );
+  });
+
+  it("returns correct path for a standalone Feature", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("F-feat", TrellisObjectType.FEATURE),
+    );
+    const result = await getAttachmentsFolder("F-feat", root);
+    expect(result).toBe(join(root, "f", "F-feat", "attachments"));
+  });
+
+  it("returns correct path for Feature under standalone Epic", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("F-feat", TrellisObjectType.FEATURE, "E-epic"),
+    );
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("E-epic", TrellisObjectType.EPIC),
+    );
+    const result = await getAttachmentsFolder("F-feat", root);
+    expect(result).toBe(
+      join(root, "e", "E-epic", "f", "F-feat", "attachments"),
+    );
+  });
+
+  it("returns correct path for Feature under Epic under Project", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("F-feat", TrellisObjectType.FEATURE, "E-epic"),
+    );
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("E-epic", TrellisObjectType.EPIC, "P-proj"),
+    );
+    const result = await getAttachmentsFolder("F-feat", root);
+    expect(result).toBe(
+      join(root, "p", "P-proj", "e", "E-epic", "f", "F-feat", "attachments"),
+    );
+  });
+
+  it("returns correct path for a standalone Task", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("T-task", TrellisObjectType.TASK),
+    );
+    const result = await getAttachmentsFolder("T-task", root);
+    expect(result).toBe(join(root, "t", "attachments", "T-task"));
+  });
+
+  it("returns correct path for Task under standalone Feature", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("T-task", TrellisObjectType.TASK, "F-feat"),
+    );
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("F-feat", TrellisObjectType.FEATURE),
+    );
+    const result = await getAttachmentsFolder("T-task", root);
+    expect(result).toBe(
+      join(root, "f", "F-feat", "t", "attachments", "T-task"),
+    );
+  });
+
+  it("returns correct path for Task under Feature under Project hierarchy", async () => {
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("T-task", TrellisObjectType.TASK, "F-feat"),
+    );
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("F-feat", TrellisObjectType.FEATURE, "E-epic"),
+    );
+    mockGetObjectById.mockResolvedValueOnce(
+      makeObj("E-epic", TrellisObjectType.EPIC, "P-proj"),
+    );
+    const result = await getAttachmentsFolder("T-task", root);
+    expect(result).toBe(
+      join(
+        root,
+        "p",
+        "P-proj",
+        "e",
+        "E-epic",
+        "f",
+        "F-feat",
+        "t",
+        "attachments",
+        "T-task",
+      ),
+    );
+  });
+});

--- a/src/repositories/local/__tests__/listAttachments.test.ts
+++ b/src/repositories/local/__tests__/listAttachments.test.ts
@@ -1,0 +1,70 @@
+import * as fsp from "fs/promises";
+import * as getAttachmentsFolderModule from "../getAttachmentsFolder";
+import { listAttachments } from "../listAttachments";
+
+jest.mock("fs/promises");
+jest.mock("../getAttachmentsFolder");
+
+const mockReaddir = jest.mocked(fsp.readdir);
+const mockGetAttachmentsFolder = jest.mocked(
+  getAttachmentsFolderModule.getAttachmentsFolder,
+);
+
+type ReadDirResult = Awaited<ReturnType<typeof fsp.readdir>>;
+
+const makeDirents = (
+  entries: Array<{ name: string; isFile: boolean }>,
+): ReadDirResult =>
+  entries.map((e) => ({
+    name: e.name,
+    isFile: () => e.isFile,
+    isDirectory: () => !e.isFile,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isSymbolicLink: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    parentPath: "",
+  })) as unknown as ReadDirResult;
+
+describe("listAttachments", () => {
+  const root = "/planning";
+  const folder = "/planning/f/F-feat/attachments";
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAttachmentsFolder.mockResolvedValue(folder);
+  });
+
+  it("returns filenames when files exist", async () => {
+    mockReaddir.mockResolvedValueOnce(
+      makeDirents([
+        { name: "report.pdf", isFile: true },
+        { name: "image.png", isFile: true },
+      ]),
+    );
+
+    const result = await listAttachments("F-feat", root);
+    expect(result).toEqual(["report.pdf", "image.png"]);
+  });
+
+  it("returns empty array when folder does not exist", async () => {
+    mockReaddir.mockRejectedValueOnce(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    const result = await listAttachments("F-feat", root);
+    expect(result).toEqual([]);
+  });
+
+  it("excludes directories from results", async () => {
+    mockReaddir.mockResolvedValueOnce(
+      makeDirents([
+        { name: "report.pdf", isFile: true },
+        { name: "subdir", isFile: false },
+      ]),
+    );
+
+    const result = await listAttachments("F-feat", root);
+    expect(result).toEqual(["report.pdf"]);
+  });
+});

--- a/src/repositories/local/copyAttachment.ts
+++ b/src/repositories/local/copyAttachment.ts
@@ -1,0 +1,44 @@
+import { access, copyFile, mkdir } from "fs/promises";
+import { basename, join } from "path";
+import { getAttachmentsFolder } from "./getAttachmentsFolder";
+
+/**
+ * Copies a file into the managed attachments folder for an issue.
+ * Throws if the issue does not exist, source file does not exist,
+ * or a file with that basename already exists in the folder.
+ * Returns the stored filename.
+ */
+export async function copyAttachment(
+  id: string,
+  sourcePath: string,
+  planningRoot: string,
+): Promise<string> {
+  try {
+    await access(sourcePath);
+  } catch {
+    throw new Error(`Source file '${sourcePath}' does not exist`);
+  }
+
+  // getAttachmentsFolder throws if issue not found
+  const folder = await getAttachmentsFolder(id, planningRoot);
+  const filename = basename(sourcePath);
+  const destPath = join(folder, filename);
+
+  let destExists = false;
+  try {
+    await access(destPath);
+    destExists = true;
+  } catch {
+    // ENOENT — no collision
+  }
+  if (destExists) {
+    throw new Error(
+      `File '${filename}' already exists in attachments for ${id}`,
+    );
+  }
+
+  await mkdir(folder, { recursive: true });
+  await copyFile(sourcePath, destPath);
+
+  return filename;
+}

--- a/src/repositories/local/deleteAttachment.ts
+++ b/src/repositories/local/deleteAttachment.ts
@@ -1,0 +1,27 @@
+import { access, unlink } from "fs/promises";
+import { join } from "path";
+import { getAttachmentsFolder } from "./getAttachmentsFolder";
+
+/**
+ * Deletes a named file from the issue's attachments folder.
+ * Throws if the issue does not exist or the file does not exist.
+ */
+export async function deleteAttachment(
+  id: string,
+  filename: string,
+  planningRoot: string,
+): Promise<void> {
+  // getAttachmentsFolder throws if issue not found
+  const folder = await getAttachmentsFolder(id, planningRoot);
+  const filePath = join(folder, filename);
+
+  try {
+    await access(filePath);
+  } catch {
+    throw new Error(
+      `File '${filename}' does not exist in attachments for ${id}`,
+    );
+  }
+
+  await unlink(filePath);
+}

--- a/src/repositories/local/deleteObjectById.ts
+++ b/src/repositories/local/deleteObjectById.ts
@@ -7,6 +7,7 @@ import {
   isRequiredForOtherObjects,
 } from "../../utils";
 import { findMarkdownFiles } from "./findMarkdownFiles";
+import { getAttachmentsFolder } from "./getAttachmentsFolder";
 
 interface FoundObject {
   filePath: string;
@@ -70,6 +71,7 @@ async function deleteAssociatedFolder(
     return;
   }
 
+  // rm -rf on the object folder also removes the attachments/ subfolder within it.
   const associatedFolderPath = dirname(filePath);
 
   try {
@@ -108,6 +110,23 @@ export async function deleteObjectById(
     await checkObjectDependencies(object, planningRoot);
   }
 
+  // Resolve task attachments folder before deletion. Best-effort: tolerate a
+  // broken parent chain (e.g., orphaned child during prune) — cleanup is skipped
+  // when the path can't be computed.
+  let taskAttachmentsFolder: string | null = null;
+  if (id.startsWith("T-")) {
+    try {
+      taskAttachmentsFolder = await getAttachmentsFolder(id, planningRoot);
+    } catch {
+      taskAttachmentsFolder = null;
+    }
+  }
+
   await deleteObjectFile(filePath);
+  // For P/E/F, deleteAssociatedFolder rm -rf covers the attachments/ subfolder.
   await deleteAssociatedFolder(id, filePath);
+
+  if (taskAttachmentsFolder) {
+    await rm(taskAttachmentsFolder, { recursive: true, force: true });
+  }
 }

--- a/src/repositories/local/getAttachmentsFolder.ts
+++ b/src/repositories/local/getAttachmentsFolder.ts
@@ -1,0 +1,80 @@
+import { join } from "path";
+import { TrellisObjectType } from "../../models/TrellisObjectType";
+import { getObjectById } from "./getObjectById";
+
+function epicFolder(id: string, parent: string | null, root: string): string {
+  if (!parent) return join(root, "e", id, "attachments");
+  return join(root, "p", parent, "e", id, "attachments");
+}
+
+async function featureFolder(
+  id: string,
+  parent: string,
+  root: string,
+): Promise<string> {
+  const epic = await getObjectById(parent, root);
+  if (!epic) throw new Error(`Parent object with ID '${parent}' not found`);
+  if (epic.type !== TrellisObjectType.EPIC)
+    throw new Error(`Feature ${id} parent must be an epic`);
+  if (!epic.parent) return join(root, "e", parent, "f", id, "attachments");
+  return join(root, "p", epic.parent, "e", parent, "f", id, "attachments");
+}
+
+async function taskFolder(
+  id: string,
+  parent: string | null,
+  root: string,
+): Promise<string> {
+  if (!parent) return join(root, "t", "attachments", id);
+  const feature = await getObjectById(parent, root);
+  if (!feature) throw new Error(`Parent object with ID '${parent}' not found`);
+  if (feature.type !== TrellisObjectType.FEATURE)
+    throw new Error(`Task ${id} parent must be a feature`);
+  if (!feature.parent) return join(root, "f", parent, "t", "attachments", id);
+  const epic = await getObjectById(feature.parent, root);
+  if (!epic)
+    throw new Error(`Parent object with ID '${feature.parent}' not found`);
+  if (epic.type !== TrellisObjectType.EPIC)
+    throw new Error(`Feature parent ${feature.parent} must be an epic`);
+  if (!epic.parent)
+    return join(root, "e", feature.parent, "f", parent, "t", "attachments", id);
+  return join(
+    root,
+    "p",
+    epic.parent,
+    "e",
+    feature.parent,
+    "f",
+    parent,
+    "t",
+    "attachments",
+    id,
+  );
+}
+
+/**
+ * Returns the managed attachments folder path for any issue type.
+ * Traverses the parent chain for tasks and features to build the correct path.
+ * Throws if the issue does not exist.
+ */
+export async function getAttachmentsFolder(
+  id: string,
+  planningRoot: string,
+): Promise<string> {
+  const obj = await getObjectById(id, planningRoot);
+  if (!obj) throw new Error(`Object with ID '${id}' not found`);
+
+  switch (obj.type) {
+    case TrellisObjectType.PROJECT:
+      return join(planningRoot, "p", id, "attachments");
+    case TrellisObjectType.EPIC:
+      return epicFolder(id, obj.parent, planningRoot);
+    case TrellisObjectType.FEATURE:
+      if (!obj.parent) return join(planningRoot, "f", id, "attachments");
+      return featureFolder(id, obj.parent, planningRoot);
+    case TrellisObjectType.TASK:
+      return taskFolder(id, obj.parent, planningRoot);
+    default:
+      throw new Error(`Unknown object type: ${String(obj.type)}`);
+  }
+}

--- a/src/repositories/local/listAttachments.ts
+++ b/src/repositories/local/listAttachments.ts
@@ -1,0 +1,24 @@
+import { readdir } from "fs/promises";
+import { getAttachmentsFolder } from "./getAttachmentsFolder";
+
+/** Returns filenames of all attachments for an issue. Returns [] if no folder exists or the parent chain is broken. */
+export async function listAttachments(
+  id: string,
+  planningRoot: string,
+): Promise<string[]> {
+  let folder: string;
+  try {
+    folder = await getAttachmentsFolder(id, planningRoot);
+  } catch {
+    return [];
+  }
+  try {
+    const entries = await readdir(folder, { withFileTypes: true });
+    return entries.filter((e) => e.isFile()).map((e) => e.name);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -21,6 +21,7 @@ import { LocalRepository, Repository } from "./repositories";
 import { TaskTrellisService } from "./services/TaskTrellisService";
 import { LocalTaskTrellisService } from "./services/local/LocalTaskTrellisService";
 import {
+  addAttachmentTool,
   appendModifiedFilesTool,
   appendObjectLogTool,
   claimTaskTool,
@@ -30,6 +31,7 @@ import {
   getNextAvailableIssueTool,
   getObjectTool,
   getUiInfoTool,
+  handleAddAttachment,
   handleAppendModifiedFiles,
   handleAppendObjectLog,
   handleClaimTask,
@@ -40,8 +42,10 @@ import {
   handleGetObject,
   handleGetUiInfo,
   handleListObjects,
+  handleRemoveAttachment,
   handleUpdateObject,
   listObjectsTool,
+  removeAttachmentTool,
   updateObjectTool,
 } from "./tools";
 
@@ -173,6 +177,8 @@ server.setRequestHandler(ListToolsRequestSchema, () => {
     getNextAvailableIssueTool,
     completeTaskTool,
     getUiInfoTool,
+    addAttachmentTool,
+    removeAttachmentTool,
   ];
 
   return { tools };
@@ -206,6 +212,10 @@ server.setRequestHandler(CallToolRequestSchema, (request) => {
       return handleCompleteTask(_getService(), repository, args, serverConfig);
     case "get_ui_info":
       return handleGetUiInfo(projectDir);
+    case "add_attachment":
+      return handleAddAttachment(_getService(), repository, args);
+    case "remove_attachment":
+      return handleRemoveAttachment(_getService(), repository, args);
     default:
       throw new Error(`Unknown tool: ${toolName}`);
   }

--- a/src/services/TaskTrellisService.ts
+++ b/src/services/TaskTrellisService.ts
@@ -104,4 +104,18 @@ export interface TaskTrellisService {
     id: string,
     filesChanged: Record<string, string>,
   ): Promise<{ content: Array<{ type: string; text: string }> }>;
+
+  /** Copies a file into the managed attachments folder for an issue. */
+  addAttachment(
+    repository: Repository,
+    id: string,
+    sourcePath: string,
+  ): Promise<{ content: Array<{ type: string; text: string }> }>;
+
+  /** Deletes a named file from the managed attachments folder for an issue. */
+  removeAttachment(
+    repository: Repository,
+    id: string,
+    filename: string,
+  ): Promise<{ content: Array<{ type: string; text: string }> }>;
 }

--- a/src/services/local/LocalTaskTrellisService.ts
+++ b/src/services/local/LocalTaskTrellisService.ts
@@ -160,4 +160,22 @@ export class LocalTaskTrellisService implements TaskTrellisService {
     const { appendModifiedFiles } = await import("./appendModifiedFiles");
     return appendModifiedFiles(repository, id, filesChanged);
   }
+
+  async addAttachment(
+    repository: Repository,
+    id: string,
+    sourcePath: string,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const { addAttachment } = await import("./addAttachment");
+    return addAttachment(repository, id, sourcePath);
+  }
+
+  async removeAttachment(
+    repository: Repository,
+    id: string,
+    filename: string,
+  ): Promise<{ content: Array<{ type: string; text: string }> }> {
+    const { removeAttachment } = await import("./removeAttachment");
+    return removeAttachment(repository, id, filename);
+  }
 }

--- a/src/services/local/__tests__/appendModifiedFiles.test.ts
+++ b/src/services/local/__tests__/appendModifiedFiles.test.ts
@@ -37,6 +37,10 @@ describe("appendModifiedFiles service function", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/services/local/__tests__/appendObjectLog.test.ts
+++ b/src/services/local/__tests__/appendObjectLog.test.ts
@@ -17,6 +17,10 @@ describe("appendObjectLog", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
     jest.clearAllMocks();
   });

--- a/src/services/local/__tests__/claimTask.test.ts
+++ b/src/services/local/__tests__/claimTask.test.ts
@@ -125,6 +125,10 @@ describe("claimTask service function", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     // Reset mocks

--- a/src/services/local/__tests__/completeTask.test.ts
+++ b/src/services/local/__tests__/completeTask.test.ts
@@ -102,6 +102,10 @@ describe("completeTask service function", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockServerConfig = {

--- a/src/services/local/__tests__/createObject.test.ts
+++ b/src/services/local/__tests__/createObject.test.ts
@@ -29,6 +29,10 @@ describe("createObject", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/services/local/__tests__/getNextAvailableIssue.test.ts
+++ b/src/services/local/__tests__/getNextAvailableIssue.test.ts
@@ -114,6 +114,10 @@ describe("getNextAvailableIssue service function", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
   });
 

--- a/src/services/local/__tests__/listObjects.test.ts
+++ b/src/services/local/__tests__/listObjects.test.ts
@@ -18,6 +18,10 @@ describe("listObjects", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/services/local/__tests__/pruneClosed.test.ts
+++ b/src/services/local/__tests__/pruneClosed.test.ts
@@ -18,6 +18,10 @@ describe("pruneClosed", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/services/local/__tests__/updateObject.test.ts
+++ b/src/services/local/__tests__/updateObject.test.ts
@@ -49,6 +49,10 @@ describe("updateObject", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockServerConfig = {

--- a/src/services/local/addAttachment.ts
+++ b/src/services/local/addAttachment.ts
@@ -1,0 +1,26 @@
+import { Repository } from "../../repositories";
+
+/** Copies a file into the managed attachments folder. Returns stored filename on success. */
+export async function addAttachment(
+  repository: Repository,
+  id: string,
+  sourcePath: string,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    const filename = await repository.copyAttachment(id, sourcePath);
+    return {
+      content: [
+        { type: "text", text: `Attachment '${filename}' added to ${id}` },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: error instanceof Error ? error.message : "Unknown error",
+        },
+      ],
+    };
+  }
+}

--- a/src/services/local/removeAttachment.ts
+++ b/src/services/local/removeAttachment.ts
@@ -1,0 +1,26 @@
+import { Repository } from "../../repositories";
+
+/** Deletes a named file from the issue's managed attachments folder. */
+export async function removeAttachment(
+  repository: Repository,
+  id: string,
+  filename: string,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  try {
+    await repository.deleteAttachment(id, filename);
+    return {
+      content: [
+        { type: "text", text: `Attachment '${filename}' removed from ${id}` },
+      ],
+    };
+  } catch (error) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: error instanceof Error ? error.message : "Unknown error",
+        },
+      ],
+    };
+  }
+}

--- a/src/tools/__tests__/addAttachmentTool.test.ts
+++ b/src/tools/__tests__/addAttachmentTool.test.ts
@@ -1,0 +1,67 @@
+import { Repository } from "../../repositories/Repository";
+import { TaskTrellisService } from "../../services/TaskTrellisService";
+import { handleAddAttachment } from "../addAttachmentTool";
+
+describe("addAttachmentTool", () => {
+  let mockService: TaskTrellisService;
+  let mockRepository: jest.Mocked<Repository>;
+  let addAttachmentSpy: jest.Mock;
+
+  beforeEach(() => {
+    addAttachmentSpy = jest.fn();
+    mockService = {
+      addAttachment: addAttachmentSpy,
+    } as unknown as TaskTrellisService;
+
+    mockRepository = {
+      getObjectById: jest.fn(),
+      getObjects: jest.fn(),
+      saveObject: jest.fn(),
+      deleteObject: jest.fn(),
+      getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it("delegates to service and returns result", async () => {
+    const mockResult = {
+      content: [
+        { type: "text", text: "Attachment 'report.pdf' added to F-feat" },
+      ],
+    };
+    addAttachmentSpy.mockResolvedValue(mockResult);
+
+    const result = await handleAddAttachment(mockService, mockRepository, {
+      id: "F-feat",
+      sourcePath: "/tmp/report.pdf",
+    });
+
+    expect(addAttachmentSpy).toHaveBeenCalledWith(
+      mockRepository,
+      "F-feat",
+      "/tmp/report.pdf",
+    );
+    expect(result).toBe(mockResult);
+  });
+
+  it("surfaces service errors", async () => {
+    const errorResult = {
+      content: [
+        { type: "text", text: "Source file '/tmp/missing.pdf' does not exist" },
+      ],
+    };
+    addAttachmentSpy.mockResolvedValue(errorResult);
+
+    const result = await handleAddAttachment(mockService, mockRepository, {
+      id: "F-feat",
+      sourcePath: "/tmp/missing.pdf",
+    });
+
+    expect(result).toBe(errorResult);
+  });
+});

--- a/src/tools/__tests__/appendModifiedFilesTool.test.ts
+++ b/src/tools/__tests__/appendModifiedFilesTool.test.ts
@@ -19,6 +19,10 @@ describe("appendModifiedFilesTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/tools/__tests__/appendObjectLogTool.test.ts
+++ b/src/tools/__tests__/appendObjectLogTool.test.ts
@@ -19,6 +19,10 @@ describe("appendObjectLogTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/tools/__tests__/claimTaskTool.test.ts
+++ b/src/tools/__tests__/claimTaskTool.test.ts
@@ -13,6 +13,10 @@ describe("claimTaskTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockService = {
@@ -25,6 +29,8 @@ describe("claimTaskTool", () => {
       appendObjectLog: jest.fn(),
       pruneClosed: jest.fn(),
       appendModifiedFiles: jest.fn(),
+      addAttachment: jest.fn(),
+      removeAttachment: jest.fn(),
     };
   });
 

--- a/src/tools/__tests__/completeTaskTool.test.ts
+++ b/src/tools/__tests__/completeTaskTool.test.ts
@@ -19,6 +19,8 @@ describe("completeTaskTool", () => {
       appendObjectLog: jest.fn(),
       pruneClosed: jest.fn(),
       appendModifiedFiles: jest.fn(),
+      addAttachment: jest.fn(),
+      removeAttachment: jest.fn(),
     };
 
     mockRepository = {
@@ -27,6 +29,10 @@ describe("completeTaskTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockServerConfig = {

--- a/src/tools/__tests__/createObjectTool.test.ts
+++ b/src/tools/__tests__/createObjectTool.test.ts
@@ -22,6 +22,10 @@ describe("createObjectTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/tools/__tests__/deleteObjectTool.test.ts
+++ b/src/tools/__tests__/deleteObjectTool.test.ts
@@ -11,6 +11,10 @@ describe("deleteObjectTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
   });
 

--- a/src/tools/__tests__/getObjectTool.test.ts
+++ b/src/tools/__tests__/getObjectTool.test.ts
@@ -17,6 +17,10 @@ describe("getObjectTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn().mockResolvedValue([]),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
   });
 
@@ -46,14 +50,48 @@ describe("getObjectTool", () => {
       });
 
       expect(mockRepository.getObjectById).toHaveBeenCalledWith("T-test-task");
+      expect(mockRepository.listAttachments).toHaveBeenCalledWith(
+        "T-test-task",
+      );
       expect(result).toEqual({
         content: [
           {
             type: "text",
-            text: `Retrieved object: ${JSON.stringify(mockTrellisObject, null, 2)}`,
+            text: `Retrieved object: ${JSON.stringify(
+              { ...mockTrellisObject, affectedFiles: {}, attachments: [] },
+              null,
+              2,
+            )}`,
           },
         ],
       });
+    });
+
+    it("should include populated attachments when files exist", async () => {
+      mockRepository.getObjectById.mockResolvedValue(mockTrellisObject);
+      mockRepository.listAttachments.mockResolvedValue([
+        "notes.pdf",
+        "diagram.png",
+      ]);
+
+      const result = await handleGetObject(mockRepository, {
+        id: "T-test-task",
+      });
+
+      expect(result.content[0].text).toContain('"attachments"');
+      expect(result.content[0].text).toContain("notes.pdf");
+      expect(result.content[0].text).toContain("diagram.png");
+    });
+
+    it("should include empty attachments array when folder is absent", async () => {
+      mockRepository.getObjectById.mockResolvedValue(mockTrellisObject);
+      mockRepository.listAttachments.mockResolvedValue([]);
+
+      const result = await handleGetObject(mockRepository, {
+        id: "T-test-task",
+      });
+
+      expect(result.content[0].text).toContain('"attachments": []');
     });
 
     it("should return not found message when object does not exist", async () => {
@@ -153,9 +191,8 @@ describe("getObjectTool", () => {
       expect(mockRepository.getObjectById).toHaveBeenCalledWith(
         "P-test-project",
       );
-      expect(result.content[0].text).toContain(
-        JSON.stringify(projectObject, null, 2),
-      );
+      expect(result.content[0].text).toContain('"attachments": []');
+      expect(result.content[0].text).toContain("P-test-project");
     });
   });
 });

--- a/src/tools/__tests__/listObjectsTool.test.ts
+++ b/src/tools/__tests__/listObjectsTool.test.ts
@@ -18,6 +18,10 @@ describe("listObjectsTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockService = {
@@ -30,6 +34,8 @@ describe("listObjectsTool", () => {
       appendObjectLog: jest.fn(),
       pruneClosed: jest.fn(),
       appendModifiedFiles: jest.fn(),
+      addAttachment: jest.fn(),
+      removeAttachment: jest.fn(),
     };
 
     // Reset mocks

--- a/src/tools/__tests__/removeAttachmentTool.test.ts
+++ b/src/tools/__tests__/removeAttachmentTool.test.ts
@@ -1,0 +1,70 @@
+import { Repository } from "../../repositories/Repository";
+import { TaskTrellisService } from "../../services/TaskTrellisService";
+import { handleRemoveAttachment } from "../removeAttachmentTool";
+
+describe("removeAttachmentTool", () => {
+  let mockService: TaskTrellisService;
+  let mockRepository: jest.Mocked<Repository>;
+  let removeAttachmentSpy: jest.Mock;
+
+  beforeEach(() => {
+    removeAttachmentSpy = jest.fn();
+    mockService = {
+      removeAttachment: removeAttachmentSpy,
+    } as unknown as TaskTrellisService;
+
+    mockRepository = {
+      getObjectById: jest.fn(),
+      getObjects: jest.fn(),
+      saveObject: jest.fn(),
+      deleteObject: jest.fn(),
+      getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
+    };
+
+    jest.clearAllMocks();
+  });
+
+  it("delegates to service and returns result", async () => {
+    const mockResult = {
+      content: [
+        { type: "text", text: "Attachment 'report.pdf' removed from F-feat" },
+      ],
+    };
+    removeAttachmentSpy.mockResolvedValue(mockResult);
+
+    const result = await handleRemoveAttachment(mockService, mockRepository, {
+      id: "F-feat",
+      filename: "report.pdf",
+    });
+
+    expect(removeAttachmentSpy).toHaveBeenCalledWith(
+      mockRepository,
+      "F-feat",
+      "report.pdf",
+    );
+    expect(result).toBe(mockResult);
+  });
+
+  it("surfaces service errors", async () => {
+    const errorResult = {
+      content: [
+        {
+          type: "text",
+          text: "File 'missing.pdf' does not exist in attachments for F-feat",
+        },
+      ],
+    };
+    removeAttachmentSpy.mockResolvedValue(errorResult);
+
+    const result = await handleRemoveAttachment(mockService, mockRepository, {
+      id: "F-feat",
+      filename: "missing.pdf",
+    });
+
+    expect(result).toBe(errorResult);
+  });
+});

--- a/src/tools/__tests__/updateObjectTool.test.ts
+++ b/src/tools/__tests__/updateObjectTool.test.ts
@@ -20,6 +20,10 @@ describe("updateObjectTool", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     mockServerConfig = {

--- a/src/tools/addAttachmentTool.ts
+++ b/src/tools/addAttachmentTool.ts
@@ -1,0 +1,32 @@
+import { Repository } from "../repositories";
+import { TaskTrellisService } from "../services/TaskTrellisService";
+
+export const addAttachmentTool = {
+  name: "add_attachment",
+  description: `Copies a file into the managed attachments folder for a Trellis issue.
+
+Errors if the issue does not exist, the source file does not exist, or a file with the same name already exists in the attachments folder.`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "ID of the Trellis issue to attach the file to",
+      },
+      sourcePath: {
+        type: "string",
+        description: "Absolute path to the source file to copy",
+      },
+    },
+    required: ["id", "sourcePath"],
+  },
+} as const;
+
+export async function handleAddAttachment(
+  service: TaskTrellisService,
+  repository: Repository,
+  args: unknown,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const { id, sourcePath } = args as { id: string; sourcePath: string };
+  return await service.addAttachment(repository, id, sourcePath);
+}

--- a/src/tools/getObjectTool.ts
+++ b/src/tools/getObjectTool.ts
@@ -58,6 +58,7 @@ export async function handleGetObject(repository: Repository, args: unknown) {
     const serializedObject = {
       ...object,
       affectedFiles: Object.fromEntries(object.affectedFiles),
+      attachments: await repository.listAttachments(id),
     };
 
     return {

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -18,3 +18,8 @@ export { getObjectTool, handleGetObject } from "./getObjectTool.js";
 export { getUiInfoTool, handleGetUiInfo } from "./getUiInfoTool.js";
 export { handleListObjects, listObjectsTool } from "./listObjectsTool.js";
 export { handleUpdateObject, updateObjectTool } from "./updateObjectTool.js";
+export { addAttachmentTool, handleAddAttachment } from "./addAttachmentTool.js";
+export {
+  handleRemoveAttachment,
+  removeAttachmentTool,
+} from "./removeAttachmentTool.js";

--- a/src/tools/removeAttachmentTool.ts
+++ b/src/tools/removeAttachmentTool.ts
@@ -1,0 +1,32 @@
+import { Repository } from "../repositories";
+import { TaskTrellisService } from "../services/TaskTrellisService";
+
+export const removeAttachmentTool = {
+  name: "remove_attachment",
+  description: `Deletes a named file from the managed attachments folder for a Trellis issue.
+
+Errors if the issue does not exist or the named file does not exist.`,
+  inputSchema: {
+    type: "object",
+    properties: {
+      id: {
+        type: "string",
+        description: "ID of the Trellis issue to remove the attachment from",
+      },
+      filename: {
+        type: "string",
+        description: "Name of the attachment file to delete",
+      },
+    },
+    required: ["id", "filename"],
+  },
+} as const;
+
+export async function handleRemoveAttachment(
+  service: TaskTrellisService,
+  repository: Repository,
+  args: unknown,
+): Promise<{ content: Array<{ type: string; text: string }> }> {
+  const { id, filename } = args as { id: string; filename: string };
+  return await service.removeAttachment(repository, id, filename);
+}

--- a/src/utils/__tests__/checkHierarchicalPrerequisitesComplete.test.ts
+++ b/src/utils/__tests__/checkHierarchicalPrerequisitesComplete.test.ts
@@ -20,6 +20,10 @@ describe("checkHierarchicalPrerequisitesComplete", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
     jest.clearAllMocks();
   });

--- a/src/utils/__tests__/checkPrerequisitesComplete.test.ts
+++ b/src/utils/__tests__/checkPrerequisitesComplete.test.ts
@@ -42,6 +42,21 @@ class MockRepository implements Repository {
     );
     return Promise.resolve(children);
   }
+  async getAttachmentsFolder(_id: string): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  async listAttachments(_id: string): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  async copyAttachment(_id: string, _sourcePath: string): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  async deleteAttachment(_id: string, _filename: string): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 describe("checkPrerequisitesComplete", () => {
@@ -288,6 +303,10 @@ describe("checkPrerequisitesComplete", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     await expect(

--- a/src/utils/__tests__/filterUnavailableObjects.test.ts
+++ b/src/utils/__tests__/filterUnavailableObjects.test.ts
@@ -42,6 +42,10 @@ describe("filterUnavailableObjects", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
   };
 

--- a/src/utils/__tests__/isRequiredForOtherObjects.test.ts
+++ b/src/utils/__tests__/isRequiredForOtherObjects.test.ts
@@ -42,6 +42,21 @@ class MockRepository implements Repository {
     );
     return Promise.resolve(children);
   }
+  async getAttachmentsFolder(_id: string): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  async listAttachments(_id: string): Promise<string[]> {
+    return Promise.resolve([]);
+  }
+
+  async copyAttachment(_id: string, _sourcePath: string): Promise<string> {
+    return Promise.resolve("");
+  }
+
+  async deleteAttachment(_id: string, _filename: string): Promise<void> {
+    return Promise.resolve();
+  }
 }
 
 describe("isRequiredForOtherObjects", () => {
@@ -318,6 +333,10 @@ describe("isRequiredForOtherObjects", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     await expect(

--- a/src/utils/__tests__/updateParentHierarchy.test.ts
+++ b/src/utils/__tests__/updateParentHierarchy.test.ts
@@ -15,6 +15,10 @@ describe("updateParentHierarchy", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
     jest.clearAllMocks();
   });

--- a/src/validation/__tests__/validateObjectCreation.test.ts
+++ b/src/validation/__tests__/validateObjectCreation.test.ts
@@ -27,6 +27,10 @@ describe("validateObjectCreation", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     testObject = {

--- a/src/validation/__tests__/validateParentExists.test.ts
+++ b/src/validation/__tests__/validateParentExists.test.ts
@@ -19,6 +19,10 @@ describe("validateParentExists", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
 
     jest.clearAllMocks();

--- a/src/validation/__tests__/validateStatusTransition.test.ts
+++ b/src/validation/__tests__/validateStatusTransition.test.ts
@@ -29,6 +29,10 @@ describe("validateStatusTransition", () => {
       saveObject: jest.fn(),
       deleteObject: jest.fn(),
       getChildrenOf: jest.fn(),
+      getAttachmentsFolder: jest.fn(),
+      listAttachments: jest.fn(),
+      copyAttachment: jest.fn(),
+      deleteAttachment: jest.fn(),
     };
     jest.clearAllMocks();
   });


### PR DESCRIPTION
Add first-class attachment support: new add_attachment / remove_attachment MCP tools, attachments field on get_issue, an HTTP route to serve attachment bytes, and per-issue attachment links in the browser UI. Storage uses <issue-folder>/attachments/ for P/E/F and t/attachments/<T-id>/ for tasks; deletion cleans up the attachments folder. Both listAttachments and the delete-cleanup path tolerate a broken parent chain (returning [] / skipping cleanup) so orphaned-child reads and prunes still succeed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>