### PR TITLE
KAN-3: Expose Trellis issues as MCP resources for @-mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Full documentation is available in the [docs](docs/index.md) folder.
 - [Installation and Configuration](#installation-and-configuration)
 - [Configuration](#configuration)
 - [Available Tools](#available-tools)
+- [MCP Resources](#mcp-resources)
 - [Troubleshooting](#troubleshooting)
 
 ## At a Glance
@@ -179,6 +180,47 @@ Attachments are returned as a list of filenames when calling **get_issue** and a
 ### System Management
 
 - **prune_closed** - Clean up old completed/cancelled issues for maintenance
+
+## MCP Resources
+
+Task Trellis exposes issues as MCP resources, enabling Claude Code to @-mention them inline for quick reference.
+
+### URI Scheme
+
+Resources follow the URI scheme: `trellis://issue/<id>`
+
+Example: `trellis://issue/T-my-task`
+
+### Which Issues Appear
+
+`resources/list` returns all **non-closed** issues — those with status `draft`, `open`, or `in-progress`. Issues with status `done` or `wont-do` are excluded.
+
+### Read Payload (Minimal by Design)
+
+`resources/read` returns **only** the issue's `id`, `title`, and `status` in a small markdown snippet:
+
+```
+# <title>
+
+- id: <id>
+- status: <status>
+```
+
+This is intentional: the resource surface is designed for **discovery and @-mention autocomplete**, not for loading full issue context into prompts. To read the full issue body, prerequisites, history, and all other fields, use the `get_issue` MCP tool instead.
+
+### @-Mention in Claude Code
+
+You can reference a Trellis issue inline in Claude Code using its MCP server name as a prefix. If your MCP configuration names the server `task-trellis` (as in the default `.mcp.json`):
+
+```
+@task-trellis:trellis://issue/T-my-task
+```
+
+If you have renamed the server, substitute that name. See the [Claude Code plugins reference](https://code.claude.com/docs/en/plugins-reference) for the current @-mention prefix format.
+
+### Stale-Context Caveat
+
+Claude Code reads each resource once per @-mention and does not refresh it during the session. If an issue is updated after being mentioned, the in-session view will be stale. Use the `get_issue` tool for fresh data.
 
 ## Troubleshooting
 

--- a/docs/observation-reports/2026-04-26-planning-sub-kan-3.md
+++ b/docs/observation-reports/2026-04-26-planning-sub-kan-3.md
@@ -1,0 +1,30 @@
+# Observation Report — Planning Sub-Session for KAN-3
+
+- **Date**: 2026-04-26
+- **Role**: Planning sub-session (top-level skill: `jira-issue-orchestration:manage-planning-team`)
+- **Jira ticket**: KAN-3 — "Expose Trellis issues as MCP resources for @-mention in Claude Code (Phase 1)"
+- **Trellis scope produced**: F-expose-trellis-issues-as-mcp (with 5 child Tasks)
+
+## What worked
+
+- The discovery → clarify → create-trellis-issues handoff was clean. The discovery skill correctly routed to `planning:discovery` (well-specified ticket with concrete ACs). Discovery surfaced two open questions; one was a real blocker (read-payload semantics) and was successfully escalated via `AskUserQuestion` in this window.
+- The user's clarification ("only id, title, and status — this is for autocomplete, not full-context loading") materially changed AC #4. Capturing it as an explicit override at the top of the requirements task ensured it survived through writer + reviewer + cross-sibling reviewer.
+- The Agent Teams loop ran end-to-end with no fix-cycle iterations. All 5 child Tasks plus the root Feature were approved on first review.
+- Cross-sibling review (mandatory at ≥3 children) caught nothing, which is the desired outcome — the breakdown was clean.
+
+## Issues / friction
+
+- **Step ordering bug in the create-trellis-issues skill**: the skill says step 2 (TaskCreate `requirements`) precedes step 4 (TeamCreate). But the team's task list only exists after TeamCreate, so the first `requirements` task created (#1) was orphaned on a different list and only the post-TeamCreate one (#2) is the real shared-task-list source-of-truth. I detected this via TaskList immediately after TeamCreate and corrected by deleting the orphan creation-task #1 and re-creating `requirements` as #2. **Recommendation**: the skill's step 2 should be moved to after step 4, or step 4 should be relocated to the very top.
+- **Read-only reviewer agents cannot file observation reports**: both `task-trellis-teams:trellis-issue-reviewer` invocations (the persistent issue-reviewer and the fresh cross-sibling-reviewer-f-expose-trellis) explicitly noted they could not write the obs report file because their agent config disallows the `Write` tool. The CLAUDE.md observation-report protocol assumes all agents can write files. **Recommendation**: either (a) update the protocol to exempt read-only roles, (b) carve out an obs-report-only Write permission in the reviewer agent definition, or (c) have the lead append a placeholder obs report on behalf of read-only teammates that surface their notes via the final message instead. Both reviewers did surface their observations in the approval messages, which I'm relaying upward in this report.
+- **Writer initial-ack pattern**: both writer agents (writer-feature, writer-tasks) went idle after the first start-nudge without sending the explicit "claimed" ack the skill specifies. In both cases the `TaskUpdate` claim itself succeeded (visible in TaskList), so a follow-up nudge resolved it. **Hypothesis**: the agents may treat the claim as the ack and skip the explicit message. The skill should either drop the explicit-ack requirement or the agent definitions should be updated to enforce it. Lead-side workaround used: TaskList check + re-nudge.
+- **Delayed message delivery**: several times during the run, an old message arrived after the corresponding task was already complete; the writer correctly diagnosed these as duplicate/delayed nudges and reported them as such instead of re-doing work. This is a correctness win for the writer agent design but it does add some chatter to the lead's inbox.
+
+## Surfaced reviewer observations (relayed since reviewers couldn't file their own)
+
+- **issue-reviewer** approved all 6 reviews (1 root + 5 children) on first pass with no findings.
+- **cross-sibling-reviewer-f-expose-trellis** quote: "all 5 sibling issues had clean non-overlapping scope, correct prerequisite chains, and full AC + README coverage."
+- **writer-tasks** filed its own obs report at `docs/observation-reports/2026-04-26-writer-tasks-issue-creation-run.md` (per its self-report — not verified by lead).
+
+## Final scope handed to conductor
+
+`scope=F-expose-trellis-issues-as-mcp` (one Feature, 5 child Tasks, externalIssueId="KAN-3").

--- a/docs/observation-reports/2026-04-26-writer-tasks-issue-creation-run.md
+++ b/docs/observation-reports/2026-04-26-writer-tasks-issue-creation-run.md
@@ -1,0 +1,37 @@
+# Observation Report — writer-tasks / issue-creation run
+
+Date: 2026-04-26  
+Agent role: writer-tasks (trellis-issue-writer teammate)  
+Run: KAN-3 / F-expose-trellis-issues-as-mcp — five child Task issues
+
+## What Happened
+
+Created five child Task issues under `F-expose-trellis-issues-as-mcp` sequentially across separate pointer nudges from the team lead:
+
+| Creation task | Trellis issue created           | Subject                            |
+| ------------- | ------------------------------- | ---------------------------------- |
+| #5            | T-implement-uri-helpers-and     | URI helpers + resource translation |
+| #7            | T-implement-handlelistresources | list + templates handlers          |
+| #9            | T-implement-handlereadresource  | read handler                       |
+| #11           | T-wire-mcp-resource-handlers    | server wiring + barrel             |
+| #13           | T-add-mcp-resources-section-to  | README docs                        |
+
+Each issue was created, metadata stored, creation task marked done, reviewer nudged, and lead notified in a single turn.
+
+## What Worked Well
+
+- The pointer-nudge → claim → ack → read-task → create → metadata → done → nudge loop was clean and mechanical once established.
+- Requirements in task #2 were detailed enough that no ambiguity escalations were needed.
+- Re-using known prerequisite IDs from prior metadata (no extra TaskGet calls needed after the first lookup) kept turns tight.
+- The duplicate task-assignment DMs (tasks #5, #7, #9, #11 each arrived as both a lead pointer and a system task_assignment JSON) were easy to handle — just ignore the duplicate and reply "already done".
+
+## What Was Awkward / Could Improve
+
+- **Duplicate activation messages**: Each creation task arrived twice — once as a clean pointer nudge from the lead and once as a JSON `task_assignment` message injected into the same inbox. The second message arrived after the work was already complete. The protocol should clarify whether the JSON message is authoritative or just a mirror; currently it creates unnecessary noise and a potential double-execution risk for agents that don't check task status first.
+- **Plugin manifest unobtainable**: The `task-trellis-teams` plugin manifest couldn't be found at any standard path (`/Users/zach/.claude/plugins/task-trellis-teams@task-trellis-marketplace/`), so the README docs task had to fall back to linking the Claude Code plugin reference docs for the @-mention prefix. Future runs should either bundle the manifest path into the creation task description or make it discoverable.
+- **Trellis issue IDs are auto-slugged and truncated**: The generated IDs (e.g. `T-implement-uri-helpers-and`) are truncated slugs of the title, which can be ambiguous for long titles. Not a blocker, but worth noting if IDs need to be user-readable.
+
+## Suggestions
+
+1. Suppress or deduplicate the `task_assignment` JSON injections when a pointer nudge is already sent — or document that agents should treat the JSON message as the canonical source and the plain-text nudge as merely a wake signal.
+2. Add the plugin manifest path (or the confirmed @-mention prefix) to the requirements task (#2) or to the README docs creation task (#13) so the writer doesn't have to hunt for it.

--- a/docs/observation-reports/writer-feature-KAN-3.md
+++ b/docs/observation-reports/writer-feature-KAN-3.md
@@ -1,0 +1,25 @@
+# Observation Report — writer-feature (KAN-3 root Feature creation)
+
+**Date**: 2026-04-25
+**Agent role**: writer-feature (Trellis issue-writer teammate)
+**Run**: jira-issue-orchestration / KAN-3 Phase 1 MCP resources
+**Created issue**: F-expose-trellis-issues-as-mcp
+
+---
+
+## What went well
+
+- The lead's task #2 (requirements) was exceptionally complete. All confirmed technical facts (server.ts line numbers, SDK schema names, Repository.getObjects semantics, test fixture pattern) saved significant research time and reduced the risk of wrong assumptions in the issue body.
+- Codebase verification was fast: `src/server.ts` matched the described state exactly (capabilities at lines 161–164, getRepository at 128–130, 13 tools in ListTools handler).
+- The SKILL.md file was not present at the expected path (`plugins/task-trellis-teams/skills/issue-creation/SKILL.md`), but the lead's task description contained sufficient guidance to proceed without it.
+
+## What was unclear / friction points
+
+- The CLAUDE.md observation report protocol has a truncated file path: the sentence "write a single markdown file to:" ends abruptly and the target directory is never stated. This required a best-effort guess at the location (`docs/observation-reports/`).
+- The SKILL.md was missing from the filesystem, so the skill authoring guide had to be inferred from general guidelines in the agent system prompt.
+
+## Suggestions for future runs
+
+- Include the full observation report target path in CLAUDE.md (the current version is broken mid-sentence).
+- Ensure `SKILL.md` and `skills/issue-creation/feature.md` are present at the paths the agent instructions reference, or update the instructions to point to the correct location.
+- The lead's task #2 pattern (rich confirmed-technical-facts section with exact file locations and line numbers) is highly effective — keep it.

--- a/src/resources/__tests__/issueResources.test.ts
+++ b/src/resources/__tests__/issueResources.test.ts
@@ -1,0 +1,282 @@
+import {
+  TrellisObjectPriority,
+  TrellisObjectStatus,
+  TrellisObjectType,
+} from "../../models";
+import type { TrellisObject } from "../../models/TrellisObject";
+import { Repository } from "../../repositories/Repository";
+import {
+  buildIssueUri,
+  decodeCursor,
+  encodeCursor,
+  handleListResources,
+  handleListResourceTemplates,
+  handleReadResource,
+  parseIssueUri,
+  toResource,
+} from "../index";
+
+const mockObject: TrellisObject = {
+  id: "T-test-task",
+  type: TrellisObjectType.TASK,
+  title: "Test Task",
+  status: TrellisObjectStatus.OPEN,
+  priority: TrellisObjectPriority.MEDIUM,
+  parent: "F-test-feature",
+  prerequisites: [],
+  affectedFiles: new Map(),
+  log: [],
+  schema: "v1.0",
+  childrenIds: [],
+  body: "Task body",
+  created: "2026-01-01T00:00:00Z",
+  updated: "2026-01-01T00:00:00Z",
+};
+
+describe("buildIssueUri", () => {
+  it("returns trellis://issue/<id>", () => {
+    expect(buildIssueUri("T-test-task")).toBe("trellis://issue/T-test-task");
+  });
+});
+
+describe("parseIssueUri", () => {
+  it("extracts the issue id from a valid URI", () => {
+    expect(parseIssueUri("trellis://issue/T-test-task")).toBe("T-test-task");
+  });
+
+  it("returns null for wrong scheme", () => {
+    expect(parseIssueUri("http://issue/T-test-task")).toBeNull();
+  });
+
+  it("returns null for wrong case (Trellis://)", () => {
+    expect(parseIssueUri("Trellis://issue/T-test-task")).toBeNull();
+  });
+
+  it("returns null when issue/ segment is missing", () => {
+    expect(parseIssueUri("trellis://T-test-task")).toBeNull();
+  });
+
+  it("returns null for empty id (trailing slash only)", () => {
+    expect(parseIssueUri("trellis://issue/")).toBeNull();
+  });
+
+  it("returns null when a query string is present", () => {
+    expect(parseIssueUri("trellis://issue/T-test-task?foo=bar")).toBeNull();
+  });
+
+  it("returns null when a fragment is present", () => {
+    expect(parseIssueUri("trellis://issue/T-test-task#anchor")).toBeNull();
+  });
+});
+
+describe("toResource", () => {
+  it("returns the correct resource shape without a size field", () => {
+    const resource = toResource(mockObject);
+
+    expect(resource).toEqual({
+      uri: "trellis://issue/T-test-task",
+      name: "T-test-task",
+      title: "Test Task",
+      description: "Test Task [open]",
+      mimeType: "text/markdown",
+    });
+    expect(resource).not.toHaveProperty("size");
+  });
+});
+
+describe("encodeCursor / decodeCursor", () => {
+  it("round-trips a non-negative integer offset", () => {
+    const cursor = encodeCursor(42);
+    expect(decodeCursor(cursor)).toBe(42);
+  });
+
+  it("round-trips offset 0", () => {
+    expect(decodeCursor(encodeCursor(0))).toBe(0);
+  });
+
+  it("encodeCursor throws on a negative offset", () => {
+    expect(() => encodeCursor(-1)).toThrow();
+  });
+
+  it("encodeCursor throws on a non-integer offset", () => {
+    expect(() => encodeCursor(1.5)).toThrow();
+  });
+
+  it("decodeCursor throws on invalid base64 payload", () => {
+    const badCursor = Buffer.from("not-a-number").toString("base64");
+    expect(() => decodeCursor(badCursor)).toThrow();
+  });
+});
+
+function makeMockRepository(): jest.Mocked<Repository> {
+  return {
+    getObjectById: jest.fn(),
+    getObjects: jest.fn(),
+    saveObject: jest.fn(),
+    deleteObject: jest.fn(),
+    getChildrenOf: jest.fn(),
+    getAttachmentsFolder: jest.fn(),
+    listAttachments: jest.fn(),
+    copyAttachment: jest.fn(),
+    deleteAttachment: jest.fn(),
+  };
+}
+
+function makeObject(
+  id: string,
+  status: TrellisObjectStatus = TrellisObjectStatus.OPEN,
+): TrellisObject {
+  return {
+    id,
+    type: TrellisObjectType.TASK,
+    title: `Title ${id}`,
+    status,
+    priority: TrellisObjectPriority.MEDIUM,
+    parent: null,
+    prerequisites: [],
+    affectedFiles: new Map(),
+    log: [],
+    schema: "v1.0",
+    childrenIds: [],
+    body: "",
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+  };
+}
+
+describe("handleListResources", () => {
+  it("returns correct resource shape for each object", async () => {
+    const repo = makeMockRepository();
+    repo.getObjects.mockResolvedValue([makeObject("T-alpha")]);
+
+    const { resources } = await handleListResources({}, repo);
+
+    expect(resources).toHaveLength(1);
+    expect(resources[0]).toEqual({
+      uri: "trellis://issue/T-alpha",
+      name: "T-alpha",
+      title: "Title T-alpha",
+      description: "Title T-alpha [open]",
+      mimeType: "text/markdown",
+    });
+  });
+
+  it("calls getObjects with false to exclude closed issues", async () => {
+    const repo = makeMockRepository();
+    repo.getObjects.mockResolvedValue([]);
+
+    await handleListResources({}, repo);
+
+    expect(repo.getObjects).toHaveBeenCalledWith(false);
+  });
+
+  it("includes draft, open, and in-progress objects", async () => {
+    const repo = makeMockRepository();
+    repo.getObjects.mockResolvedValue([
+      makeObject("T-a", TrellisObjectStatus.DRAFT),
+      makeObject("T-b", TrellisObjectStatus.OPEN),
+      makeObject("T-c", TrellisObjectStatus.IN_PROGRESS),
+    ]);
+
+    const { resources } = await handleListResources({}, repo);
+
+    const ids = resources.map((r) => r.name);
+    expect(ids).toContain("T-a");
+    expect(ids).toContain("T-b");
+    expect(ids).toContain("T-c");
+  });
+
+  it("paginates across two pages for 150 items", async () => {
+    const repo = makeMockRepository();
+    const items = Array.from({ length: 150 }, (_, i) =>
+      makeObject(`T-${String(i).padStart(3, "0")}`),
+    );
+    repo.getObjects.mockResolvedValue(items);
+
+    const page1 = await handleListResources({}, repo);
+    expect(page1.resources).toHaveLength(100);
+    expect(page1.nextCursor).toBeDefined();
+
+    const page2 = await handleListResources({ cursor: page1.nextCursor }, repo);
+    expect(page2.resources).toHaveLength(50);
+    expect(page2.nextCursor).toBeUndefined();
+  });
+
+  it("returns empty resources and no nextCursor when getObjects returns []", async () => {
+    const repo = makeMockRepository();
+    repo.getObjects.mockResolvedValue([]);
+
+    const result = await handleListResources({}, repo);
+
+    expect(result).toEqual({ resources: [] });
+    expect(result.nextCursor).toBeUndefined();
+  });
+});
+
+describe("handleListResourceTemplates", () => {
+  it("returns the trellis-issue template", () => {
+    const { resourceTemplates } = handleListResourceTemplates();
+
+    expect(resourceTemplates).toHaveLength(1);
+    expect(resourceTemplates[0]).toEqual({
+      uriTemplate: "trellis://issue/{id}",
+      name: "trellis-issue",
+      title: "Trellis Issue",
+      description:
+        "A Trellis issue (project, epic, feature, or task) referenced by ID",
+      mimeType: "text/markdown",
+    });
+  });
+});
+
+describe("handleReadResource", () => {
+  it("returns minimal payload for a known id", async () => {
+    const repo = makeMockRepository();
+    const obj = makeObject("T-known", TrellisObjectStatus.IN_PROGRESS);
+    obj.body = "should not appear";
+    repo.getObjectById.mockResolvedValue(obj);
+
+    const result = await handleReadResource(
+      { uri: "trellis://issue/T-known" },
+      repo,
+    );
+
+    const text = result.contents[0].text;
+    expect(text).toContain("Title T-known");
+    expect(text).toContain("T-known");
+    expect(text).toContain("in-progress");
+    expect(text).not.toContain("should not appear");
+    expect(text).not.toContain("prerequisites");
+    expect(text).not.toContain("parent");
+    expect(text).not.toContain("log");
+  });
+
+  it("throws with the id when the issue is not found", async () => {
+    const repo = makeMockRepository();
+    repo.getObjectById.mockResolvedValue(null);
+
+    await expect(
+      handleReadResource({ uri: "trellis://issue/T-missing" }, repo),
+    ).rejects.toThrow("Trellis issue not found: T-missing");
+  });
+
+  it("throws before calling repository when URI has no issue/ segment", async () => {
+    const repo = makeMockRepository();
+
+    await expect(
+      handleReadResource({ uri: "trellis://T-no-segment" }, repo),
+    ).rejects.toThrow();
+
+    expect(repo.getObjectById).not.toHaveBeenCalled();
+  });
+
+  it("throws before calling repository for http:// scheme", async () => {
+    const repo = makeMockRepository();
+
+    await expect(
+      handleReadResource({ uri: "http://issue/T-wrong-scheme" }, repo),
+    ).rejects.toThrow();
+
+    expect(repo.getObjectById).not.toHaveBeenCalled();
+  });
+});

--- a/src/resources/buildIssueUri.ts
+++ b/src/resources/buildIssueUri.ts
@@ -1,0 +1,6 @@
+const URI_PREFIX = "trellis://issue/";
+
+/** Returns the trellis resource URI for an issue. */
+export function buildIssueUri(id: string): string {
+  return `${URI_PREFIX}${id}`;
+}

--- a/src/resources/decodeCursor.ts
+++ b/src/resources/decodeCursor.ts
@@ -1,0 +1,13 @@
+/**
+ * Decodes a base64 cursor back to an integer offset.
+ * Throws if the decoded value is not a valid non-negative integer.
+ */
+export function decodeCursor(cursor: string): number {
+  const decoded = Buffer.from(cursor, "base64").toString("utf8");
+  if (!/^\d+$/.test(decoded)) {
+    throw new Error(
+      `decodeCursor: "${cursor}" does not decode to a non-negative integer`,
+    );
+  }
+  return parseInt(decoded, 10);
+}

--- a/src/resources/encodeCursor.ts
+++ b/src/resources/encodeCursor.ts
@@ -1,0 +1,12 @@
+/**
+ * Base64-encodes a pagination offset for use as a cursor.
+ * Throws if `offset` is negative or non-integer.
+ */
+export function encodeCursor(offset: number): string {
+  if (!Number.isInteger(offset) || offset < 0) {
+    throw new Error(
+      `encodeCursor: offset must be a non-negative integer, got ${offset}`,
+    );
+  }
+  return Buffer.from(String(offset)).toString("base64");
+}

--- a/src/resources/handleListResourceTemplates.ts
+++ b/src/resources/handleListResourceTemplates.ts
@@ -1,0 +1,19 @@
+import type { ResourceTemplate } from "@modelcontextprotocol/sdk/types.js";
+
+/** Returns the MCP resource template for Trellis issues. */
+export function handleListResourceTemplates(): {
+  resourceTemplates: ResourceTemplate[];
+} {
+  return {
+    resourceTemplates: [
+      {
+        uriTemplate: "trellis://issue/{id}",
+        name: "trellis-issue",
+        title: "Trellis Issue",
+        description:
+          "A Trellis issue (project, epic, feature, or task) referenced by ID",
+        mimeType: "text/markdown",
+      },
+    ],
+  };
+}

--- a/src/resources/handleListResources.ts
+++ b/src/resources/handleListResources.ts
@@ -1,0 +1,24 @@
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Repository } from "../repositories/Repository";
+import { decodeCursor } from "./decodeCursor";
+import { encodeCursor } from "./encodeCursor";
+import { toResource } from "./issueResources";
+
+const PAGE_SIZE = 100;
+
+/** Lists open Trellis issues as MCP resources with cursor-based pagination. */
+export async function handleListResources(
+  { cursor }: { cursor?: string },
+  repository: Repository,
+): Promise<{ resources: Resource[]; nextCursor?: string }> {
+  const offset = cursor !== undefined ? decodeCursor(cursor) : 0;
+  const all = await repository.getObjects(false);
+  const sorted = [...all].sort((a, b) => a.id.localeCompare(b.id));
+  const page = sorted.slice(offset, offset + PAGE_SIZE);
+  const resources = page.map(toResource);
+  const nextCursor =
+    offset + PAGE_SIZE < sorted.length
+      ? encodeCursor(offset + PAGE_SIZE)
+      : undefined;
+  return nextCursor !== undefined ? { resources, nextCursor } : { resources };
+}

--- a/src/resources/handleReadResource.ts
+++ b/src/resources/handleReadResource.ts
@@ -1,0 +1,30 @@
+import type { Repository } from "../repositories/Repository";
+import { parseIssueUri } from "./parseIssueUri";
+
+/** Reads a Trellis issue by URI and returns its minimal MCP resource contents (id, title, status only). */
+export async function handleReadResource(
+  { uri }: { uri: string },
+  repository: Repository,
+): Promise<{
+  contents: Array<{ uri: string; mimeType: string; text: string }>;
+}> {
+  const parsedId = parseIssueUri(uri);
+  if (parsedId === null) {
+    throw new Error(`Invalid Trellis issue URI: ${uri}`);
+  }
+
+  const obj = await repository.getObjectById(parsedId);
+  if (obj === null) {
+    throw new Error(`Trellis issue not found: ${parsedId}`);
+  }
+
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: "text/markdown",
+        text: `# ${obj.title}\n\n- id: ${obj.id}\n- status: ${obj.status}`,
+      },
+    ],
+  };
+}

--- a/src/resources/index.ts
+++ b/src/resources/index.ts
@@ -1,0 +1,8 @@
+export { buildIssueUri } from "./buildIssueUri";
+export { decodeCursor } from "./decodeCursor";
+export { encodeCursor } from "./encodeCursor";
+export { handleListResources } from "./handleListResources";
+export { handleListResourceTemplates } from "./handleListResourceTemplates";
+export { handleReadResource } from "./handleReadResource";
+export { toResource } from "./issueResources";
+export { parseIssueUri } from "./parseIssueUri";

--- a/src/resources/issueResources.ts
+++ b/src/resources/issueResources.ts
@@ -1,0 +1,14 @@
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { TrellisObject } from "../models/TrellisObject";
+import { buildIssueUri } from "./buildIssueUri";
+
+/** Converts a TrellisObject to an MCP Resource. */
+export function toResource(obj: TrellisObject): Resource {
+  return {
+    uri: buildIssueUri(obj.id),
+    name: obj.id,
+    title: obj.title,
+    description: `${obj.title} [${obj.status}]`,
+    mimeType: "text/markdown",
+  };
+}

--- a/src/resources/parseIssueUri.ts
+++ b/src/resources/parseIssueUri.ts
@@ -1,0 +1,11 @@
+const URI_PATTERN = /^trellis:\/\/issue\/([^?#]+)$/;
+
+/**
+ * Extracts the issue ID from a `trellis://issue/<id>` URI.
+ * Returns null for any malformed input: wrong scheme, wrong case, missing `issue/` segment,
+ * empty id, or query string / fragment present.
+ */
+export function parseIssueUri(uri: string): string | null {
+  const match = URI_PATTERN.exec(uri);
+  return match ? match[1] : null;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -5,6 +5,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import {
   CallToolRequestSchema,
   ListToolsRequestSchema,
+  ListResourcesRequestSchema,
+  ReadResourceRequestSchema,
+  ListResourceTemplatesRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { Command } from "commander";
 import fs from "fs";
@@ -48,6 +51,11 @@ import {
   removeAttachmentTool,
   updateObjectTool,
 } from "./tools";
+import {
+  handleListResources,
+  handleListResourceTemplates,
+  handleReadResource,
+} from "./resources";
 
 // Parse command line arguments
 const program = new Command();
@@ -160,6 +168,7 @@ A browser UI is also available; call get_ui_info to retrieve its URL whenever th
   {
     capabilities: {
       tools: {},
+      resources: { listChanged: true },
     },
   },
 );
@@ -219,6 +228,18 @@ server.setRequestHandler(CallToolRequestSchema, (request) => {
     default:
       throw new Error(`Unknown tool: ${toolName}`);
   }
+});
+
+server.setRequestHandler(ListResourcesRequestSchema, (request) => {
+  return handleListResources(request.params ?? {}, getRepository());
+});
+
+server.setRequestHandler(ListResourceTemplatesRequestSchema, () => {
+  return handleListResourceTemplates();
+});
+
+server.setRequestHandler(ReadResourceRequestSchema, (request) => {
+  return handleReadResource(request.params, getRepository());
 });
 
 async function runServer() {


### PR DESCRIPTION
## What

Adds MCP resource support so active Trellis issues show up in Claude Code's @-mention autocomplete under the `trellis://issue/<id>` scheme. The resource response only includes id, title, and status to keep the dropdown clean — full issue bodies still come from the existing `get_issue` tool. No changes to the existing 13 tools.

## Why

Removes the copy/paste friction of grabbing Trellis issue IDs from the browser UI when referencing them in prompts. This establishes a discovery surface distinct from the model-driven `get_issue` tool, setting the contract for future Trellis @-mention UX (Phase 2 will layer `list_changed` notifications on top).

## Jira ticket

[KAN-3](https://langadventure.atlassian.net/browse/KAN-3)

## Steps to Validate/Verify

- `mise run quality` and `mise run test` both pass
- In Claude Code with the `task-trellis-teams` plugin installed, type `@` and verify active Trellis issues appear in the autocomplete dropdown, and that selecting one inserts a `trellis://issue/<id>` reference

## Additional Notes

N/A