### PR TITLE
KAN-4: Default project tree to active work and persist user state

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,15 @@ Task Trellis UI: http://127.0.0.1:3717
 - The UI shows all projects under `~/.trellis/projects/` and supports creating, editing, and deleting issues directly in the browser.
 - When the leader session exits, the port is released automatically.
 
+#### Project Tree Navigation
+
+The project tree view includes several features for navigating and filtering issues:
+
+- **Expand/Collapse**: Click the chevron next to an issue to expand or collapse its children. Open/closed state is automatically saved per project.
+- **Hide Completed**: Click the filter icon (top toolbar) to toggle hiding completed (done/wont-do) issues. This preference is saved per project.
+- **Search**: Use the search box to filter issues by title or content. Search results are displayed flat and ignore the hide-completed preference.
+- **Issue Details**: Click any issue row to view and edit its full details in the side panel.
+
 ### Breaking Changes
 
 > **Breaking change:** `--projectRootFolder` has been removed. Use `--projectDir` instead.

--- a/src/http/__tests__/projectTreePage.test.ts
+++ b/src/http/__tests__/projectTreePage.test.ts
@@ -103,6 +103,8 @@ describe("projectTreeHandler", () => {
     expect(html).toContain("/projects/my-proj/issues/search");
     expect(html).toContain("<strong>3</strong> issues");
     expect(html).toContain("1 open · 1 in-progress · 1 done");
+    // DONE task is pruned from the tree by default; meta-bar counts are unaffected
+    expect(html).not.toContain("Task Three");
   });
 
   it("renders search input wired to search endpoint", async () => {
@@ -115,6 +117,44 @@ describe("projectTreeHandler", () => {
     expect(html).toContain('hx-get="/projects/my-proj/issues/search"');
     expect(html).toContain('hx-trigger="keyup changed delay:200ms"');
     expect(html).toContain('id="detail"');
+  });
+
+  it("emits filter-toggle button with id, aria-label, and icon-btn class", async () => {
+    mockGetObjects.mockResolvedValue([]);
+
+    const res = makeRes();
+    await projectTreeHandler(makeReq(), res, { key: "my-proj" });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain('id="filter-toggle"');
+    expect(html).toContain('aria-label="Toggle hide completed"');
+    expect(html).toContain('class="icon-btn" id="filter-toggle"');
+  });
+
+  it("emits data-project-key on the #issue-tree nav", async () => {
+    mockGetObjects.mockResolvedValue([]);
+
+    const res = makeRes();
+    await projectTreeHandler(makeReq(), res, { key: "my-proj" });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain('id="issue-tree"');
+    expect(html).toContain('data-project-key="my-proj"');
+  });
+
+  it("inline script reconciles filter state on load: triggers refreshTree when hideDone is false", async () => {
+    mockGetObjects.mockResolvedValue([]);
+
+    const res = makeRes();
+    await projectTreeHandler(makeReq(), res, { key: "my-proj" });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    // The DOMContentLoaded handler must capture loadHideDone() and, when false,
+    // trigger refreshTree so the server-pruned tree is replaced with the full tree.
+    expect(html).toContain("var hideDone = loadHideDone()");
+    expect(html).toContain(
+      "if (!hideDone) htmx.trigger(document.body, 'refreshTree')",
+    );
   });
 
   it("renders tree nodes with kind letter and correct status/priority classes", async () => {
@@ -219,6 +259,183 @@ describe("searchHandler", () => {
     const html = (res.end as jest.Mock).mock.calls[0][0] as string;
     expect(html).toContain("Some Task");
     expect(html).not.toContain("Another");
+  });
+
+  it("prunes completed subtrees when hideDone=1 and q is absent", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "T-open",
+        title: "Open Task",
+        status: TrellisObjectStatus.OPEN,
+      }),
+      makeObj({
+        id: "T-done",
+        title: "Done Task",
+        status: TrellisObjectStatus.DONE,
+      }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?hideDone=1"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain("Open Task");
+    expect(html).not.toContain("Done Task");
+  });
+
+  it("does not prune when hideDone=1 and q is present (search ignores filter)", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "T-open",
+        title: "foo open",
+        status: TrellisObjectStatus.OPEN,
+      }),
+      makeObj({
+        id: "T-done",
+        title: "foo done",
+        status: TrellisObjectStatus.DONE,
+      }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?hideDone=1&q=foo"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain("foo open");
+    expect(html).toContain("foo done");
+  });
+
+  it("meta-bar OOB reflects full dataset counts even when hideDone=1 prunes the tree", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({ id: "T-open", status: TrellisObjectStatus.OPEN }),
+      makeObj({ id: "T-done", status: TrellisObjectStatus.DONE }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?hideDone=1"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    expect(html).toContain("<strong>2</strong> issues");
+    expect(html).toContain("1 open");
+    expect(html).toContain("1 done");
+  });
+
+  it("honors open CSV param: renders matching rows with open class when q is absent", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "F-parent",
+        title: "Parent Feature",
+        type: TrellisObjectType.FEATURE,
+        childrenIds: ["T-child"],
+        parent: null,
+      }),
+      makeObj({ id: "T-child", title: "Child Task", parent: "F-parent" }),
+      makeObj({
+        id: "F-other",
+        title: "Other Feature",
+        type: TrellisObjectType.FEATURE,
+        childrenIds: [],
+        parent: null,
+      }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?open=F-parent"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    // F-parent is in openSet → renders with open class
+    expect(html).toMatch(/class="row open"/);
+    expect(html).toContain("Parent Feature");
+  });
+
+  it("search-clear path: honors open CSV when q is empty string (q=&open=...)", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "F-parent",
+        title: "Parent Feature",
+        type: TrellisObjectType.FEATURE,
+        childrenIds: ["T-child"],
+        parent: null,
+      }),
+      makeObj({ id: "T-child", title: "Child Task", parent: "F-parent" }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?q=&open=F-parent"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    // q="" is falsy → tree mode; F-parent in openSet → open class rendered
+    expect(html).toMatch(/class="row open"/);
+    expect(html).toContain("Parent Feature");
+  });
+
+  it("empty open param renders no rows expanded (explicitly all-collapsed state)", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "F-inprogress",
+        title: "In Progress Feature",
+        type: TrellisObjectType.FEATURE,
+        status: TrellisObjectStatus.IN_PROGRESS,
+        childrenIds: ["T-child"],
+        parent: null,
+      }),
+      makeObj({ id: "T-child", title: "Child Task", parent: "F-inprogress" }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(makeReq("/projects/my-proj/issues/search?open="), res, {
+      key: "my-proj",
+    });
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    // open="" → empty openSet overrides computeInitialOpenSet → no row has open class
+    expect(html).not.toMatch(/class="row open"/);
+    expect(html).toContain("In Progress Feature");
+  });
+
+  it("ignores open param when q is present (search results are flat)", async () => {
+    mockGetObjects.mockResolvedValue([
+      makeObj({
+        id: "F-parent",
+        title: "Parent Feature",
+        type: TrellisObjectType.FEATURE,
+        childrenIds: ["T-child"],
+        parent: null,
+      }),
+      makeObj({ id: "T-child", title: "Child Task", parent: "F-parent" }),
+    ]);
+
+    const res = makeRes();
+    await searchHandler(
+      makeReq("/projects/my-proj/issues/search?q=Parent&open=F-parent"),
+      res,
+      { key: "my-proj" },
+    );
+
+    const html = (res.end as jest.Mock).mock.calls[0][0] as string;
+    // Search returns flat results; open class must not appear
+    expect(html).not.toMatch(/class="row open"/);
+    expect(html).toContain("Parent Feature");
   });
 
   it("returns no-results message when nothing matches", async () => {

--- a/src/http/appShell.ts
+++ b/src/http/appShell.ts
@@ -9,20 +9,71 @@ const SVG_SPRITE = `<svg width="0" height="0" style="position:absolute" aria-hid
 <symbol id="i-alert" viewBox="0 0 18 18"><path d="M9 2L2 15h14L9 2z" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linejoin="round"/><path d="M9 7v4M9 13v.5" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/></symbol>
 <symbol id="i-sun" viewBox="0 0 14 14"><circle cx="7" cy="7" r="2.5" fill="none" stroke="currentColor" stroke-width="1.3"/><path d="M7 1.5v1.5M7 11v1.5M1.5 7H3M11 7h1.5M3.1 3.1l1 1M9.9 9.9l1 1M3.1 10.9l1-1M9.9 4.1l1-1" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/></symbol>
 <symbol id="i-moon" viewBox="0 0 14 14"><path d="M11 8.5A4.5 4.5 0 015.5 3a4.5 4.5 0 104.8 5.8c-.4-.2 0-.2-.3-.3z" fill="currentColor"/></symbol>
+<symbol id="i-filter-on" viewBox="0 0 14 14"><path d="M2 3h10l-3.8 4.4V11.5l-2.4-.9V7.4L2 3z" fill="currentColor"/></symbol>
+<symbol id="i-filter-off" viewBox="0 0 14 14"><path d="M2 3h10l-3.8 4.4V11.5l-2.4-.9V7.4L2 3z" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linejoin="round"/></symbol>
 </defs></svg>`;
 
 const INLINE_SCRIPT = `(function(){
-  var saved = localStorage.getItem('tt-theme') || 'dark';
+  var saved;
+  try { saved = localStorage.getItem('tt-theme') || 'dark'; } catch(e) { saved = 'dark'; }
   document.documentElement.setAttribute('data-theme', saved);
   function applyTheme(t){
     document.documentElement.setAttribute('data-theme', t);
-    localStorage.setItem('tt-theme', t);
+    try { localStorage.setItem('tt-theme', t); } catch(e) {}
     var btn = document.getElementById('theme-toggle');
     if (!btn) return;
     var light = btn.querySelector('.theme-icon-light');
     var dark = btn.querySelector('.theme-icon-dark');
     if (light) light.style.display = t === 'dark' ? 'none' : '';
     if (dark) dark.style.display = t === 'dark' ? '' : 'none';
+  }
+  function treeKey(){
+    var nav = document.getElementById('issue-tree');
+    var k = nav && nav.dataset.projectKey;
+    return k ? 'tt-tree:' + k + ':open' : null;
+  }
+  function filterKey(){
+    var nav = document.getElementById('issue-tree');
+    var k = nav && nav.dataset.projectKey;
+    return k ? 'tt-tree:' + k + ':hideDone' : null;
+  }
+  function loadHideDone(){
+    try {
+      var key = filterKey();
+      if (!key) return true;
+      var raw = localStorage.getItem(key);
+      return raw === null ? true : raw === '1';
+    } catch(e) { return true; }
+  }
+  function saveHideDone(val){
+    try {
+      var key = filterKey();
+      if (!key) return;
+      localStorage.setItem(key, val ? '1' : '0');
+    } catch(e) {}
+  }
+  function applyFilter(hideDone){
+    var btn = document.getElementById('filter-toggle');
+    if (!btn) return;
+    var on = btn.querySelector('.filter-icon-on');
+    var off = btn.querySelector('.filter-icon-off');
+    if (on) on.style.display = hideDone ? '' : 'none';
+    if (off) off.style.display = hideDone ? 'none' : '';
+  }
+  function loadOpenSet(){
+    try {
+      var key = treeKey();
+      if (!key) return null;
+      var raw = localStorage.getItem(key);
+      return raw ? new Set(JSON.parse(raw)) : null;
+    } catch(e) { return null; }
+  }
+  function saveOpenSet(set){
+    try {
+      var key = treeKey();
+      if (!key) return;
+      localStorage.setItem(key, JSON.stringify(Array.from(set)));
+    } catch(e) {}
   }
   function indentOf(el){
     var v = el.style.getPropertyValue('--indent') || '0';
@@ -42,6 +93,12 @@ const INLINE_SCRIPT = `(function(){
         el.classList.remove('open');
       }
       el = el.nextElementSibling;
+    }
+    var id = row.dataset.id;
+    if (id) {
+      var set = loadOpenSet() || new Set();
+      if (opened) { set.add(id); } else { set.delete(id); }
+      saveOpenSet(set);
     }
   }
   function wire(root){
@@ -70,12 +127,89 @@ const INLINE_SCRIPT = `(function(){
         applyTheme(next);
       });
     }
+    var ft = root.getElementById && root.getElementById('filter-toggle');
+    if (ft && !ft.dataset.ttWired) {
+      ft.dataset.ttWired = '1';
+      ft.addEventListener('click', function(){
+        var next = !loadHideDone();
+        saveHideDone(next);
+        applyFilter(next);
+        htmx.trigger(document.body, 'refreshTree');
+      });
+    }
+  }
+  function applyStoredOpenSet(){
+    var set = loadOpenSet();
+    if (!set) return;
+    document.querySelectorAll('#issue-tree .row[data-id]').forEach(function(row){
+      var id = row.dataset.id;
+      var hasChev = !!row.querySelector('.chev:not(.hidden)');
+      var isOpen = row.classList.contains('open');
+      var shouldBeOpen = set.has(id) && hasChev;
+      var indent = indentOf(row);
+      if (shouldBeOpen && !isOpen) {
+        row.classList.add('open');
+        var el = row.nextElementSibling;
+        while (el && el.classList && el.classList.contains('row')) {
+          var ei = indentOf(el);
+          if (ei <= indent) break;
+          if (ei === indent + 20) el.hidden = false;
+          el = el.nextElementSibling;
+        }
+      } else if (!shouldBeOpen && isOpen) {
+        row.classList.remove('open');
+        var el = row.nextElementSibling;
+        while (el && el.classList && el.classList.contains('row')) {
+          var ei = indentOf(el);
+          if (ei <= indent) break;
+          el.hidden = true;
+          el.classList.remove('open');
+          el = el.nextElementSibling;
+        }
+      }
+    });
   }
   document.addEventListener('DOMContentLoaded', function(){
     applyTheme(saved);
+    var hideDone = loadHideDone();
+    applyFilter(hideDone);
     wire(document);
+    applyStoredOpenSet();
+    if (!hideDone) htmx.trigger(document.body, 'refreshTree');
   });
-  document.addEventListener('htmx:afterSwap', function(){ wire(document); });
+  document.addEventListener('htmx:afterSwap', function(evt){
+    wire(document);
+    if (evt.detail && evt.detail.target && evt.detail.target.id === 'issue-tree') {
+      try {
+        var key = treeKey();
+        if (!key) return;
+        var raw = localStorage.getItem(key);
+        if (!raw) return;
+        var stored = JSON.parse(raw);
+        var presentIds = new Set();
+        document.querySelectorAll('#issue-tree [data-id]').forEach(function(el){
+          presentIds.add(el.dataset.id);
+        });
+        var pruned = stored.filter(function(id){ return presentIds.has(id); });
+        localStorage.setItem(key, JSON.stringify(pruned));
+      } catch(e) {}
+    }
+  });
+  document.addEventListener('htmx:configRequest', function(evt){
+    if (evt.detail && evt.detail.target && evt.detail.target.id === 'issue-tree') {
+      try {
+        var key = treeKey();
+        if (key) {
+          var raw = localStorage.getItem(key);
+          if (raw !== null) {
+            var ids = JSON.parse(raw);
+            if (ids) evt.detail.parameters['open'] = ids.join(',');
+          }
+        }
+      } catch(e) {}
+      evt.detail.parameters['hideDone'] = loadHideDone() ? '1' : '0';
+    }
+  });
 })();`;
 
 /** Returns a full HTML document with designer stylesheet, SVG sprite, HTMX, and theme/tree scripts. */

--- a/src/http/projectTreePage/__tests__/computeInitialOpenSet.test.ts
+++ b/src/http/projectTreePage/__tests__/computeInitialOpenSet.test.ts
@@ -1,0 +1,96 @@
+import {
+  TrellisObjectPriority,
+  TrellisObjectStatus,
+  TrellisObjectType,
+} from "../../../models";
+import type { TrellisObject } from "../../../models";
+import { computeInitialOpenSet } from "../computeInitialOpenSet";
+import { treeRow } from "../treeRow";
+
+function makeObj(overrides: Partial<TrellisObject> = {}): TrellisObject {
+  return {
+    id: "T-test",
+    type: TrellisObjectType.TASK,
+    title: "Test Task",
+    status: TrellisObjectStatus.OPEN,
+    priority: TrellisObjectPriority.MEDIUM,
+    parent: null,
+    prerequisites: [],
+    affectedFiles: new Map(),
+    log: [],
+    schema: "v1.0",
+    childrenIds: [],
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("treeRow", () => {
+  it("emits data-id attribute matching the object id", () => {
+    const task = makeObj({ id: "T-abc", childrenIds: [] });
+    const html = treeRow("my-proj", task, 0);
+    expect(html).toContain('data-id="T-abc"');
+  });
+});
+
+describe("computeInitialOpenSet", () => {
+  it("includes the in-progress issue's own id when it has children", () => {
+    const parent = makeObj({
+      id: "F-parent",
+      type: TrellisObjectType.FEATURE,
+      status: TrellisObjectStatus.IN_PROGRESS,
+      childrenIds: ["T-child"],
+      parent: null,
+    });
+    const child = makeObj({ id: "T-child", parent: "F-parent" });
+
+    const open = computeInitialOpenSet([parent, child]);
+
+    expect(open.has("F-parent")).toBe(true);
+  });
+
+  it("includes ancestors of in-progress issues (regression)", () => {
+    const grandparent = makeObj({
+      id: "P-gp",
+      type: TrellisObjectType.PROJECT,
+      childrenIds: ["F-mid"],
+      parent: null,
+    });
+    const middle = makeObj({
+      id: "F-mid",
+      type: TrellisObjectType.FEATURE,
+      childrenIds: ["T-leaf"],
+      parent: "P-gp",
+    });
+    const leaf = makeObj({
+      id: "T-leaf",
+      status: TrellisObjectStatus.IN_PROGRESS,
+      parent: "F-mid",
+    });
+
+    const open = computeInitialOpenSet([grandparent, middle, leaf]);
+
+    expect(open.has("P-gp")).toBe(true);
+    expect(open.has("F-mid")).toBe(true);
+  });
+
+  it("includes a childless in-progress id in the set but treeRow renders no open class", () => {
+    const task = makeObj({
+      id: "T-solo",
+      status: TrellisObjectStatus.IN_PROGRESS,
+      childrenIds: [],
+      parent: null,
+    });
+
+    const open = computeInitialOpenSet([task]);
+
+    // The id is in the open set
+    expect(open.has("T-solo")).toBe(true);
+
+    // But treeRow omits the open class because there are no children
+    const html = treeRow("my-proj", task, 0, { open: true });
+    expect(html).not.toContain(" open");
+  });
+});

--- a/src/http/projectTreePage/__tests__/pruneCompletedSubtrees.test.ts
+++ b/src/http/projectTreePage/__tests__/pruneCompletedSubtrees.test.ts
@@ -1,0 +1,89 @@
+import {
+  TrellisObjectPriority,
+  TrellisObjectStatus,
+  TrellisObjectType,
+} from "../../../models";
+import type { TrellisObject } from "../../../models";
+import { pruneCompletedSubtrees } from "../pruneCompletedSubtrees";
+
+function makeObj(overrides: Partial<TrellisObject> = {}): TrellisObject {
+  return {
+    id: "T-test",
+    type: TrellisObjectType.TASK,
+    title: "Test Task",
+    status: TrellisObjectStatus.OPEN,
+    priority: TrellisObjectPriority.MEDIUM,
+    parent: null,
+    prerequisites: [],
+    affectedFiles: new Map(),
+    log: [],
+    schema: "v1.0",
+    childrenIds: [],
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("pruneCompletedSubtrees", () => {
+  it("removes a done root and all its descendants, even if descendants are open or in-progress", () => {
+    const root = makeObj({
+      id: "F-done",
+      type: TrellisObjectType.FEATURE,
+      status: TrellisObjectStatus.DONE,
+      childrenIds: ["T-open", "T-progress"],
+    });
+    const open = makeObj({ id: "T-open", parent: "F-done" });
+    const progress = makeObj({
+      id: "T-progress",
+      status: TrellisObjectStatus.IN_PROGRESS,
+      parent: "F-done",
+    });
+    const other = makeObj({ id: "T-other" });
+
+    const result = pruneCompletedSubtrees([root, open, progress, other]);
+
+    const ids = result.map((o) => o.id);
+    expect(ids).not.toContain("F-done");
+    expect(ids).not.toContain("T-open");
+    expect(ids).not.toContain("T-progress");
+    expect(ids).toContain("T-other");
+  });
+
+  it("removes a wont-do subtree the same way", () => {
+    const root = makeObj({
+      id: "F-wontdo",
+      type: TrellisObjectType.FEATURE,
+      status: TrellisObjectStatus.WONT_DO,
+      childrenIds: ["T-child"],
+    });
+    const child = makeObj({ id: "T-child", parent: "F-wontdo" });
+
+    const result = pruneCompletedSubtrees([root, child]);
+
+    expect(result).toHaveLength(0);
+  });
+
+  it("keeps non-closed roots and their subtrees intact", () => {
+    const root = makeObj({
+      id: "F-open",
+      type: TrellisObjectType.FEATURE,
+      status: TrellisObjectStatus.OPEN,
+      childrenIds: ["T-child"],
+    });
+    const child = makeObj({ id: "T-child", parent: "F-open" });
+    const inProgress = makeObj({
+      id: "T-progress",
+      status: TrellisObjectStatus.IN_PROGRESS,
+    });
+
+    const result = pruneCompletedSubtrees([root, child, inProgress]);
+
+    const ids = result.map((o) => o.id);
+    expect(ids).toContain("F-open");
+    expect(ids).toContain("T-child");
+    expect(ids).toContain("T-progress");
+    expect(result).toHaveLength(3);
+  });
+});

--- a/src/http/projectTreePage/__tests__/renderTreeFragment.test.ts
+++ b/src/http/projectTreePage/__tests__/renderTreeFragment.test.ts
@@ -1,0 +1,124 @@
+import {
+  TrellisObjectPriority,
+  TrellisObjectStatus,
+  TrellisObjectType,
+} from "../../../models";
+import type { TrellisObject } from "../../../models";
+import { renderTreeFragment } from "../renderTreeFragment";
+
+function makeObj(overrides: Partial<TrellisObject> = {}): TrellisObject {
+  return {
+    id: "T-test",
+    type: TrellisObjectType.TASK,
+    title: "Test Task",
+    status: TrellisObjectStatus.OPEN,
+    priority: TrellisObjectPriority.MEDIUM,
+    parent: null,
+    prerequisites: [],
+    affectedFiles: new Map(),
+    log: [],
+    schema: "v1.0",
+    childrenIds: [],
+    created: "2026-01-01T00:00:00Z",
+    updated: "2026-01-01T00:00:00Z",
+    body: "",
+    ...overrides,
+  };
+}
+
+describe("renderTreeFragment", () => {
+  it("honors a supplied openSet — matching IDs render with open class, others do not", () => {
+    const parent = makeObj({
+      id: "F-open",
+      type: TrellisObjectType.FEATURE,
+      title: "Open Feature",
+      childrenIds: ["T-child"],
+      parent: null,
+    });
+    const child = makeObj({ id: "T-child", parent: "F-open" });
+    const other = makeObj({
+      id: "F-closed",
+      type: TrellisObjectType.FEATURE,
+      title: "Closed Feature",
+      childrenIds: ["T-other-child"],
+      parent: null,
+    });
+    const otherChild = makeObj({ id: "T-other-child", parent: "F-closed" });
+
+    // Only F-open is in the supplied openSet
+    const openSet = new Set(["F-open"]);
+    const html = renderTreeFragment(
+      "my-proj",
+      [parent, child, other, otherChild],
+      { openSet },
+    );
+
+    // F-open has children and is in openSet → renders with open class
+    expect(html).toMatch(/class="row open"/);
+    // F-closed has children but is NOT in openSet → no open class
+    const closedIdx = html.indexOf("Closed Feature");
+    const openIdx = html.indexOf("Open Feature");
+    // Closed Feature row must not have open class; verify the row's class attribute
+    const closedRowStart = html.lastIndexOf('<div class="row', closedIdx);
+    expect(html.slice(closedRowStart, closedIdx)).not.toContain("open");
+    // Open Feature row comes before its content
+    expect(openIdx).toBeGreaterThan(-1);
+    expect(closedIdx).toBeGreaterThan(-1);
+  });
+
+  it("with hideCompleted:true excludes done subtree IDs from HTML", () => {
+    const doneRoot = makeObj({
+      id: "F-done",
+      type: TrellisObjectType.FEATURE,
+      title: "Done Feature",
+      status: TrellisObjectStatus.DONE,
+      childrenIds: ["T-done-child"],
+      parent: null,
+    });
+    const doneChild = makeObj({
+      id: "T-done-child",
+      title: "Done Child",
+      parent: "F-done",
+    });
+    const openRoot = makeObj({
+      id: "F-open",
+      type: TrellisObjectType.FEATURE,
+      title: "Open Feature",
+      parent: null,
+    });
+
+    const html = renderTreeFragment(
+      "my-proj",
+      [doneRoot, doneChild, openRoot],
+      { hideCompleted: true },
+    );
+
+    expect(html).not.toContain("F-done");
+    expect(html).not.toContain("T-done-child");
+    expect(html).toContain("F-open");
+  });
+
+  it("falls back to computeInitialOpenSet when openSet is omitted", () => {
+    // F-parent has an in-progress child → computeInitialOpenSet will include F-parent
+    const parent = makeObj({
+      id: "F-parent",
+      type: TrellisObjectType.FEATURE,
+      title: "Parent Feature",
+      childrenIds: ["T-inprogress"],
+      parent: null,
+    });
+    const inProgress = makeObj({
+      id: "T-inprogress",
+      title: "In Progress Task",
+      status: TrellisObjectStatus.IN_PROGRESS,
+      parent: "F-parent",
+    });
+
+    // No options passed — should use computeInitialOpenSet
+    const html = renderTreeFragment("my-proj", [parent, inProgress]);
+
+    // F-parent is an ancestor of an in-progress task → open class expected
+    expect(html).toMatch(/class="row open"/);
+    expect(html).toContain("Parent Feature");
+  });
+});

--- a/src/http/projectTreePage/computeInitialOpenSet.ts
+++ b/src/http/projectTreePage/computeInitialOpenSet.ts
@@ -1,11 +1,12 @@
 import { TrellisObjectStatus, type TrellisObject } from "../../models";
 
-/** IDs of rows that should start expanded: ancestors of any in-progress issue. */
+/** IDs of rows that should start expanded: in-progress issues themselves and their ancestors. */
 export function computeInitialOpenSet(objects: TrellisObject[]): Set<string> {
   const byId = new Map(objects.map((o) => [o.id, o]));
   const open = new Set<string>();
   for (const o of objects) {
     if (o.status !== TrellisObjectStatus.IN_PROGRESS) continue;
+    open.add(o.id);
     let parentId = o.parent;
     while (parentId && !open.has(parentId)) {
       open.add(parentId);

--- a/src/http/projectTreePage/projectTreeHandler.ts
+++ b/src/http/projectTreePage/projectTreeHandler.ts
@@ -24,7 +24,7 @@ export async function projectTreeHandler(
 
   const repo = makeRepo(key);
   const allObjects = await repo.getObjects(true);
-  const treeHtml = renderTreeFragment(key, allObjects);
+  const treeHtml = renderTreeFragment(key, allObjects, { hideCompleted: true });
   const keyEsc = escapeHtml(key);
 
   const sidebar = `<aside class="sidebar">
@@ -40,6 +40,10 @@ export async function projectTreeHandler(
       <button class="icon-btn" id="theme-toggle" title="Toggle dark mode" aria-label="Toggle dark mode" type="button">
         <svg class="theme-icon-light"><use href="#i-moon"/></svg>
         <svg class="theme-icon-dark"><use href="#i-sun"/></svg>
+      </button>
+      <button class="icon-btn" id="filter-toggle" title="Toggle hide completed" aria-label="Toggle hide completed" type="button">
+        <svg class="filter-icon-on"><use href="#i-filter-on"/></svg>
+        <svg class="filter-icon-off"><use href="#i-filter-off"/></svg>
       </button>
       <button class="icon-btn" title="New top-level issue" type="button"
         hx-get="/projects/${keyEsc}/issues/new" hx-target="#detail" hx-swap="innerHTML">
@@ -61,6 +65,7 @@ export async function projectTreeHandler(
 
   <nav class="tree"
     id="issue-tree"
+    data-project-key="${keyEsc}"
     hx-trigger="refreshTree from:body"
     hx-get="/projects/${keyEsc}/issues/search"
     hx-swap="innerHTML">

--- a/src/http/projectTreePage/pruneCompletedSubtrees.ts
+++ b/src/http/projectTreePage/pruneCompletedSubtrees.ts
@@ -1,0 +1,28 @@
+import type { TrellisObject } from "../../models";
+import { isClosed } from "../../models";
+
+/** Removes closed (done/wont-do) subtrees and all their descendants from the object list. */
+export function pruneCompletedSubtrees(
+  objects: TrellisObject[],
+): TrellisObject[] {
+  const byId = new Map(objects.map((o) => [o.id, o]));
+  const blocked = new Set<string>();
+
+  function collect(id: string): void {
+    if (blocked.has(id)) return;
+    blocked.add(id);
+    const obj = byId.get(id);
+    if (!obj) return;
+    for (const childId of obj.childrenIds) {
+      collect(childId);
+    }
+  }
+
+  for (const o of objects) {
+    if (isClosed(o)) {
+      collect(o.id);
+    }
+  }
+
+  return objects.filter((o) => !blocked.has(o.id));
+}

--- a/src/http/projectTreePage/renderTreeFragment.ts
+++ b/src/http/projectTreePage/renderTreeFragment.ts
@@ -1,5 +1,6 @@
 import type { TrellisObject } from "../../models";
 import { computeInitialOpenSet } from "./computeInitialOpenSet";
+import { pruneCompletedSubtrees } from "./pruneCompletedSubtrees";
 import { treeRow } from "./treeRow";
 
 function buildNodes(
@@ -35,19 +36,24 @@ function buildNodes(
     .join("\n");
 }
 
-/** Renders the hierarchical tree. Ancestors of in-progress issues start expanded; everything else collapsed. */
+/** Renders the hierarchical tree. Ancestors of in-progress issues start expanded; everything else collapsed.
+ * Supply `options.openSet` to override which rows start open. Pass `options.hideCompleted: true` to prune done/wont-do subtrees before rendering. */
 export function renderTreeFragment(
   key: string,
   objects: TrellisObject[],
+  options?: { openSet?: Set<string>; hideCompleted?: boolean },
 ): string {
-  const objectMap = new Map(objects.map((o) => [o.id, o]));
-  const roots = objects.filter((o) => o.parent === null);
-  const openSet = computeInitialOpenSet(objects);
+  const visible = options?.hideCompleted
+    ? pruneCompletedSubtrees(objects)
+    : objects;
+  const objectMap = new Map(visible.map((o) => [o.id, o]));
+  const roots = visible.filter((o) => o.parent === null);
+  const openSet = options?.openSet ?? computeInitialOpenSet(visible);
   const html = buildNodes(
     key,
     objectMap,
     openSet,
-    roots.map((o) => o.id),
+    roots.map((r) => r.id),
     0,
     true,
   );

--- a/src/http/projectTreePage/searchHandler.ts
+++ b/src/http/projectTreePage/searchHandler.ts
@@ -24,16 +24,28 @@ export async function searchHandler(
   const { key } = params;
   const url = new URL(req.url ?? "/", "http://localhost");
   const q = url.searchParams.get("q") ?? "";
+  const hideDone = url.searchParams.get("hideDone");
+  const openParam = url.searchParams.get("open");
 
   const repo = makeRepo(key);
   const allObjects = await repo.getObjects(true);
 
-  const tree = q
-    ? renderFlatFragment(
-        key,
-        allObjects.filter((o) => matchesQuery(o, q)),
-      )
-    : renderTreeFragment(key, allObjects);
+  let tree: string;
+  if (q) {
+    tree = renderFlatFragment(
+      key,
+      allObjects.filter((o) => matchesQuery(o, q)),
+    );
+  } else {
+    const openSet =
+      openParam !== null
+        ? new Set(openParam.split(",").filter(Boolean))
+        : undefined;
+    tree = renderTreeFragment(key, allObjects, {
+      hideCompleted: hideDone === "1",
+      ...(openSet ? { openSet } : {}),
+    });
+  }
 
   const metaOob = `<div class="tree-meta" id="tree-meta" hx-swap-oob="true">${metaBar(allObjects)}</div>`;
 

--- a/src/http/projectTreePage/treeRow.ts
+++ b/src/http/projectTreePage/treeRow.ts
@@ -21,7 +21,7 @@ export function treeRow(
   const openClass = hasChildren && opts.open ? " open" : "";
   const hiddenAttr = opts.hidden ? " hidden" : "";
   const indentPx = depth * 20;
-  return `<div class="row${openClass}"${hiddenAttr} style="--indent:${indentPx}px;"
+  return `<div class="row${openClass}"${hiddenAttr} data-id="${escapeHtml(obj.id)}" style="--indent:${indentPx}px;"
   hx-get="/projects/${escapeHtml(key)}/issues/${escapeHtml(obj.id)}/detail"
   hx-target="#detail"
   hx-swap="innerHTML"


### PR DESCRIPTION
## What

The HTTP UI's project tree now puts your active work front and center. In-progress issues expand automatically on load, completed issues are hidden behind a sidebar toggle, and your expand/collapse state sticks across HTMX swaps and full reloads. State is per-project, so switching projects gives you a clean slate.

## Why

The sidebar was noisy by default and didn't remember what users had open. On long-lived projects, hundreds of finished issues drowned out current work, and any folder a user expanded or collapsed got reset on the next refresh. This change turns the project tree into a focused view of active work that remembers your state, while still letting you reach closed history when you need it.

## Jira ticket

[KAN-4](https://langadventure.atlassian.net/browse/KAN-4)

## Steps to Validate/Verify

- Visit `/projects/<project-key>` in the browser UI; in-progress issues should render expanded on first load.
- Confirm completed (done / wont-do) issues are hidden by default; click the funnel toggle in the sidebar header to reveal them and again to hide.
- Expand or collapse a few rows, hard-reload the page — state is preserved per project.
- Trigger a CRUD action (create/edit/delete) so HTMX fires `refreshTree` — expanded set is preserved.
- Search with a query — search results ignore the hide-completed filter so any closed issue is still findable.

## Additional Notes

State persistence falls back gracefully when `localStorage` is unavailable (private browsing) — server-side defaults take over. Counts in the meta bar always reflect the full unfiltered dataset so totals don't drift when the filter is on.
