### PR TITLE
KAN-7: Stop frontmatter corruption from --- inside YAML values

### DIFF
--- a/src/utils/__tests__/deserializeTrellisObject.test.ts
+++ b/src/utils/__tests__/deserializeTrellisObject.test.ts
@@ -505,4 +505,84 @@ Test body content with parent set to 'none'`;
     expect(result.id).toBe("P-none-parent-test");
     expect(result.title).toBe("None Parent Test");
   });
+
+  describe("closing-fence line-anchoring regression cases", () => {
+    const minimalFrontmatter = `id: T-parser-test
+title: Test Task
+status: open
+priority: medium
+prerequisites: []
+affectedFiles: {}
+log: []
+schema: v1.0
+childrenIds: []
+created: "2025-01-15T10:00:00Z"
+updated: "2025-01-15T10:00:00Z"`;
+
+    it("ignores --- inside a double-quoted scalar and finds the real closing fence", () => {
+      const markdownString = `---
+${minimalFrontmatter.replace("title: Test Task", 'title: "has --- inside"')}
+---
+
+body content`;
+
+      const result = deserializeTrellisObject(markdownString);
+      expect(result.body).toBe("body content");
+      expect(result.title).toBe("has --- inside");
+    });
+
+    it("ignores --- inside a single-quoted scalar and finds the real closing fence", () => {
+      const markdownString = `---
+${minimalFrontmatter.replace("title: Test Task", "title: 'has --- inside'")}
+---
+
+body content`;
+
+      const result = deserializeTrellisObject(markdownString);
+      expect(result.body).toBe("body content");
+      expect(result.title).toBe("has --- inside");
+    });
+
+    it("ignores bare --- line nested inside a block-literal scalar (line-anchoring)", () => {
+      const markdownString = `---
+id: T-parser-test
+title: Test Task
+status: open
+priority: medium
+prerequisites: []
+log: []
+schema: v1.0
+childrenIds: []
+created: "2025-01-15T10:00:00Z"
+updated: "2025-01-15T10:00:00Z"
+affectedFiles:
+  src/f.ts: |-
+    line1
+    ---
+    line2
+---
+
+body content`;
+
+      const result = deserializeTrellisObject(markdownString);
+      expect(result.body).toBe("body content");
+      expect(result.affectedFiles.get("src/f.ts")).toBe("line1\n---\nline2");
+    });
+
+    it("parses correctly when closing fence has trailing whitespace", () => {
+      const markdownString = `---\n${minimalFrontmatter}\n---   \n\nbody content`;
+
+      const result = deserializeTrellisObject(markdownString);
+      expect(result.body).toBe("body content");
+      expect(result.id).toBe("T-parser-test");
+    });
+
+    it("throws the exact error message when no closing fence is present", () => {
+      const markdownString = `---\n${minimalFrontmatter}`;
+
+      expect(() => deserializeTrellisObject(markdownString)).toThrow(
+        "Invalid format: Expected YAML frontmatter delimited by --- markers",
+      );
+    });
+  });
 });

--- a/src/utils/__tests__/serializationRoundTrip.test.ts
+++ b/src/utils/__tests__/serializationRoundTrip.test.ts
@@ -1,3 +1,4 @@
+import { Scalar } from "yaml";
 import {
   TrellisObject,
   TrellisObjectPriority,
@@ -6,6 +7,7 @@ import {
 } from "../../models";
 import { deserializeTrellisObject } from "../deserializeTrellisObject";
 import { serializeTrellisObject } from "../serializeTrellisObject";
+import { wrapDangerousScalars } from "../wrapDangerousScalars";
 
 describe("TrellisObject Serialization/Deserialization Integration Tests", () => {
   describe("Round-trip serialization compatibility", () => {
@@ -506,6 +508,97 @@ ${"Final section content repeated multiple times to test large content handling.
 
       expect(deserialized).toEqual(original);
       expect(deserialized.parent).toBeNull();
+    });
+  });
+
+  describe("triple-dash corruption regression cases", () => {
+    const base: TrellisObject = {
+      id: "T-dash-test",
+      type: TrellisObjectType.TASK,
+      title: "Dash Test",
+      status: TrellisObjectStatus.OPEN,
+      priority: TrellisObjectPriority.MEDIUM,
+      prerequisites: [],
+      affectedFiles: new Map(),
+      log: [],
+      schema: "v1.0",
+      childrenIds: [],
+      body: "test body",
+      created: "2025-01-15T10:00:00Z",
+      updated: "2025-01-15T10:00:00Z",
+      parent: null,
+    };
+
+    it("round-trips when affectedFiles value contains \\n---\\n", () => {
+      const original: TrellisObject = {
+        ...base,
+        affectedFiles: new Map([["src/f.ts", "line1\n---\nline2"]]),
+      };
+      expect(
+        deserializeTrellisObject(serializeTrellisObject(original)),
+      ).toEqual(original);
+    });
+
+    it("round-trips when log entry contains \\n---\\n", () => {
+      const original: TrellisObject = {
+        ...base,
+        log: ["before\n---\nafter"],
+      };
+      expect(
+        deserializeTrellisObject(serializeTrellisObject(original)),
+      ).toEqual(original);
+    });
+
+    it("round-trips when title is exactly ---", () => {
+      const original: TrellisObject = { ...base, title: "---" };
+      expect(
+        deserializeTrellisObject(serializeTrellisObject(original)),
+      ).toEqual(original);
+    });
+
+    it("round-trips when title contains \\n---\\n", () => {
+      const original: TrellisObject = { ...base, title: "Title\n---\nMore" };
+      expect(
+        deserializeTrellisObject(serializeTrellisObject(original)),
+      ).toEqual(original);
+    });
+
+    it("round-trips long affectedFiles value with \\n---\\n (serializer guard fires for block-literal candidate)", () => {
+      const longValue = "A".repeat(80) + "\n---\n" + "B".repeat(80);
+      const original: TrellisObject = {
+        ...base,
+        affectedFiles: new Map([["src/f.ts", longValue]]),
+      };
+      const serialized = serializeTrellisObject(original);
+      // Guard must prevent a bare --- line from appearing in the frontmatter region
+      const frontmatterRegion = serialized.split(/^---\s*$/m)[1];
+      expect(frontmatterRegion).not.toMatch(/^---\s*$/m);
+      expect(deserializeTrellisObject(serialized)).toEqual(original);
+    });
+
+    it("round-trips log entry with --- mid-line only — guard must NOT trigger (negative test)", () => {
+      const original: TrellisObject = {
+        ...base,
+        log: ["see config---v2.yml"],
+      };
+      const serialized = serializeTrellisObject(original);
+      // Mid-line --- should not be double-quoted; confirm plain output
+      expect(serialized).toContain("see config---v2.yml");
+      expect(deserializeTrellisObject(serialized)).toEqual(original);
+    });
+  });
+
+  describe("wrapDangerousScalars unit tests", () => {
+    it("wraps string with bare --- line as QUOTE_DOUBLE Scalar", () => {
+      const result = wrapDangerousScalars("line1\n---\nline2");
+      expect(result).toBeInstanceOf(Scalar);
+      expect((result as Scalar).type).toBe(Scalar.QUOTE_DOUBLE);
+    });
+
+    it("leaves mid-line --- string unchanged (negative case)", () => {
+      const result = wrapDangerousScalars("see config---v2.yml");
+      expect(typeof result).toBe("string");
+      expect(result).toBe("see config---v2.yml");
     });
   });
 });

--- a/src/utils/deserializeTrellisObject.ts
+++ b/src/utils/deserializeTrellisObject.ts
@@ -13,27 +13,37 @@ function extractFrontmatterAndBody(markdownString: string): {
   yamlContent: string;
   bodyContent: string;
 } {
-  const frontmatterStart = markdownString.indexOf("---");
-  if (frontmatterStart === -1) {
+  if (!markdownString.startsWith("---")) {
     throw new Error(
       "Invalid format: Expected YAML frontmatter delimited by --- markers",
     );
   }
 
-  const frontmatterEnd = markdownString.indexOf("---", frontmatterStart + 3);
-  if (frontmatterEnd === -1) {
+  const openFenceNewlineIndex = markdownString.indexOf("\n");
+  if (openFenceNewlineIndex === -1) {
     throw new Error(
       "Invalid format: Expected YAML frontmatter delimited by --- markers",
     );
   }
 
-  const yamlContent = markdownString
-    .substring(frontmatterStart + 3, frontmatterEnd)
+  const afterOpenFence = markdownString.substring(openFenceNewlineIndex + 1);
+  const closingFenceMatch = /^---\s*$/m.exec(afterOpenFence);
+  if (!closingFenceMatch) {
+    throw new Error(
+      "Invalid format: Expected YAML frontmatter delimited by --- markers",
+    );
+  }
+
+  const yamlContent = afterOpenFence
+    .substring(0, closingFenceMatch.index)
     .trim();
 
-  const bodyContent = markdownString
-    .substring(frontmatterEnd + 3)
-    .replace(/^\n+/, "");
+  const bodyStart =
+    openFenceNewlineIndex +
+    1 +
+    closingFenceMatch.index +
+    closingFenceMatch[0].length;
+  const bodyContent = markdownString.substring(bodyStart).replace(/^\n+/, "");
 
   return { yamlContent, bodyContent };
 }

--- a/src/utils/serializeTrellisObject.ts
+++ b/src/utils/serializeTrellisObject.ts
@@ -1,5 +1,6 @@
 import { stringify } from "yaml";
 import { TrellisObject } from "../models";
+import { wrapDangerousScalars } from "./wrapDangerousScalars";
 
 /**
  * Serializes a TrellisObject to a markdown string with YAML frontmatter
@@ -29,8 +30,8 @@ export function serializeTrellisObject(trellisObject: TrellisObject): string {
       : {}),
   };
 
-  // Generate YAML frontmatter
-  const yamlFrontmatter = stringify(frontmatter).trim();
+  // Guard against bare --- lines in scalar values that would confuse the frontmatter extractor
+  const yamlFrontmatter = stringify(wrapDangerousScalars(frontmatter)).trim();
 
   // Combine YAML frontmatter with markdown body
   const markdown = `---

--- a/src/utils/wrapDangerousScalars.ts
+++ b/src/utils/wrapDangerousScalars.ts
@@ -1,0 +1,33 @@
+import { Scalar } from "yaml";
+
+/**
+ * Recursively wraps any string scalar containing a bare `---` line as a QUOTE_DOUBLE Scalar node,
+ * preventing yaml.stringify from emitting bare `---` lines inside frontmatter that would confuse
+ * the frontmatter extractor.
+ * Example: wrapDangerousScalars("line1\n---\nline2") → Scalar node with type QUOTE_DOUBLE.
+ * Strings with `---` only mid-line (e.g. "see config---v2.yml") are left unchanged.
+ */
+export function wrapDangerousScalars(obj: unknown): unknown {
+  if (typeof obj === "string") {
+    if (/^---$/m.test(obj)) {
+      // QUOTE_DOUBLE prevents block-literal style, which would emit bare --- lines
+      // that confuse the frontmatter extractor. Escalate if yaml overrides this type hint.
+      const scalar = new Scalar(obj);
+      scalar.type = Scalar.QUOTE_DOUBLE;
+      return scalar;
+    }
+    return obj;
+  }
+  if (Array.isArray(obj)) {
+    return obj.map(wrapDangerousScalars);
+  }
+  if (obj !== null && typeof obj === "object") {
+    return Object.fromEntries(
+      Object.entries(obj as Record<string, unknown>).map(([k, v]) => [
+        k,
+        wrapDangerousScalars(v),
+      ]),
+    );
+  }
+  return obj;
+}


### PR DESCRIPTION
## What

Fixes a bug where Trellis frontmatter could be corrupted if a YAML string value contained a bare `---` line. The parser was using a plain substring search for the closing fence, so an embedded `---` would truncate the frontmatter and the file would be rewritten broken on the next save.

The closing-fence search is now line-anchored, and the serializer quotes any string scalar containing a bare `---` line so neither read nor write can produce an unparseable file. Twelve regression tests cover the previously broken cases plus a negative case for mid-line `---`.

## Why

Once a feature or epic file's frontmatter gets corrupted, every subsequent write to tasks underneath it (`complete_task`, `append_modified_files`, `append_issue_log`) fails with `Parent object with ID '<id>' not found` until someone hand-edits the file. Hardening both the parser and serializer eliminates the failure mode and prevents normal writes from re-introducing the corruption.

## Jira ticket

[KAN-7](https://langadventure.atlassian.net/browse/KAN-7)

## Steps to Validate/Verify

- `mise run quality` — lint/format/type-check pass
- `mise run test` — full suite passes including 12 new regression cases under `src/utils/__tests__/`

## Additional Notes

N/A